### PR TITLE
Fix Version Check to allow 4.1

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -4,8 +4,8 @@ const {SHRParser} = require('./parsers/SHRParser');
 const {SHRParserVisitor} = require('./parsers/SHRParserVisitor');
 const {Version} = require('shr-models');
 
-const VERSION = new Version(4, 0, 0);
-const GRAMMAR_VERSION = new Version(4, 0, 0);
+const VERSION = new Version(4, 1, 1);
+const GRAMMAR_VERSION = new Version(4, 1, 0);
 
 class Preprocessor extends SHRParserVisitor {
   constructor() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-text-import",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Imports Standard Health Record (SHR) elements from their custom grammar to the SHR models",
   "author": "",
   "license": "Apache-2.0",

--- a/test/fixtures/dataElement/codeableConceptFromValueSet/CodeableConceptFromValueSet.txt
+++ b/test/fixtures/dataElement/codeableConceptFromValueSet/CodeableConceptFromValueSet.txt
@@ -1,4 +1,4 @@
-Grammar:    DataElement 4.0
+Grammar:    DataElement 4.1
 Namespace:  shr.test
 Uses:       shr.core
 CodeSystem: MTH = http://uts.nlm.nih.gov/metathesaurus

--- a/test/fixtures/dataElement/includesCodeConstraintsUsingCodeableConcept/IncludesCodeConstraints.txt
+++ b/test/fixtures/dataElement/includesCodeConstraintsUsingCodeableConcept/IncludesCodeConstraints.txt
@@ -1,4 +1,4 @@
-Grammar:    DataElement 4.0
+Grammar:    DataElement 4.1
 Namespace:  shr.test
 Uses:       shr.core
 

--- a/test/fixtures/map/ChoicePathMapping_map.txt
+++ b/test/fixtures/map/ChoicePathMapping_map.txt
@@ -1,4 +1,4 @@
-Grammar:	Map 4.0
+Grammar:	Map 4.1
 Namespace:	shr.test
 Target:		TEST
 

--- a/test/fixtures/map/DeepPathMapping_map.txt
+++ b/test/fixtures/map/DeepPathMapping_map.txt
@@ -1,4 +1,4 @@
-Grammar:	Map 4.0
+Grammar:	Map 4.1
 Namespace:	shr.test
 Target:		TEST
 

--- a/test/fixtures/map/SimpleMapping_map.txt
+++ b/test/fixtures/map/SimpleMapping_map.txt
@@ -1,4 +1,4 @@
-Grammar:	Map 4.0
+Grammar:	Map 4.1
 Namespace:	shr.test
 Target:		TEST
 

--- a/test/map-import-test.js
+++ b/test/map-import-test.js
@@ -6,7 +6,7 @@ describe('#importFromFilePath()', () => {
   it('should correctly import a simple mapping', () => {
     const {specifications, errors} = importFixture('SimpleMapping');
     expect(errors).is.empty;
-    expectVersions(specifications, new mdls.Version(4));
+    expectVersions(specifications, new mdls.Version(4,1));
     expectTargets(specifications, 'TEST');
     const s = getAndExpect(specifications, 'shr.test', 'A', 'TEST', 'B');
     expect(s.rules).to.eql([
@@ -19,7 +19,7 @@ describe('#importFromFilePath()', () => {
   it('should correctly import a mapping with deep paths', () => {
     const {specifications, errors} = importFixture('DeepPathMapping');
     expect(errors).is.empty;
-    expectVersions(specifications, new mdls.Version(4));
+    expectVersions(specifications, new mdls.Version(4,1));
     expectTargets(specifications, 'TEST');
     const s = getAndExpect(specifications, 'shr.test', 'A', 'TEST', 'B');
     expect(s.rules).to.eql([
@@ -32,7 +32,7 @@ describe('#importFromFilePath()', () => {
   it('should correctly import a mapping with paths and choices', () => {
     const {specifications, errors} = importFixture('ChoicePathMapping');
     expect(errors).is.empty;
-    expectVersions(specifications, new mdls.Version(4));
+    expectVersions(specifications, new mdls.Version(4,1));
     expectTargets(specifications, 'TEST');
     const s = getAndExpect(specifications, 'shr.test', 'A', 'TEST', 'B');
     expect(s.rules).to.eql([


### PR DESCRIPTION
Fix the grammar version check to allow Grammar 4.1 files.  This also bumps up its own version to 4.1.1.