### PR TITLE
Support Value Set Constraints on Elements w/ code values

### DIFF
--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -240,11 +240,11 @@ class DataElementImporter extends SHRDataElementParserListener {
           const onValue = cst.elementTypeConstraint().KW_VALUE_IS_TYPE() ? true : false;
           value.addConstraint(new TypeConstraint(newIdentifier, path, onValue));
         } else if (cst.elementCodeVSConstraint()) {
-          const codeFromVS = cst.elementCodeVSConstraint().codeFromVS();
-          const codeIdentifier = this.resolveCodeFromVSIdentifier(codeFromVS);
-          const vs = this.resolveCodeFromVSValueSet(codeFromVS);
-          const strength = this.resolveCodeFromVSBindingStrength(codeFromVS);
-          value.addConstraint(new ValueSetConstraint(vs, [...path, codeIdentifier], strength));
+          const vsConstraint = cst.elementCodeVSConstraint();
+          const vs = this.resolveValueSetForVSConstraint(vsConstraint); // TODO: Fix
+          const strength = this.resolveBindingStrengthForVSConstraint(vsConstraint); // TODO: Fix
+          // NOTE: The contraint may be on a non-code-like element.  The "expander" will adjust the path as necessary.
+          value.addConstraint(new ValueSetConstraint(vs, path, strength));
         } else if (cst.elementCodeValueConstraint()) {
           const code = this.processCodeOrFQCode(cst.elementCodeValueConstraint().codeOrFQCode());
           value.addConstraint(new CodeConstraint(code, path));
@@ -277,35 +277,18 @@ class DataElementImporter extends SHRDataElementParserListener {
       }
     } else if (ctx.primitive()) {
       value = new IdentifiableValue(new PrimitiveIdentifier(ctx.getText()));
-    } else if (ctx.codeFromVS()) {
-      const codeIdentifier = this.resolveCodeFromVSIdentifier(ctx.codeFromVS());
-      const vs = this.resolveCodeFromVSValueSet(ctx.codeFromVS());
-      const strength = this.resolveCodeFromVSBindingStrength(ctx.codeFromVS());
-      value = new IdentifiableValue(codeIdentifier);
-      value.addConstraint(new ValueSetConstraint(vs).withBindingStrength(strength));
     }
+
     if (typeof min !== 'undefined') {
       value.setMinMax(min, max);
     }
     return value;
   }
 
-  resolveCodeFromVSIdentifier(codeFromVS) {
-    if (codeFromVS.simpleOrFQName()) {
-      const identifier = this.resolveToIdentifier(codeFromVS.simpleOrFQName().getText());
-      if (identifier.name != 'Coding' && identifier.name != 'CodeableConcept') {
-        // Currently, we only want to support this when it is explicitly Coding or CodeableConcept
-        logger.error('Value Set constraint on non-code element: %s', identifier.fqn);
-      }
-      return identifier;
-    }
-    return new PrimitiveIdentifier('code');
-  }
-
-  resolveCodeFromVSValueSet(codeFromVS) {
-    let vs = codeFromVS.valueset().getText();
-    if (codeFromVS.valueset().PATH_URL()) {
-      const [path, name] =  codeFromVS.valueset().PATH_URL().getText().split('/', 2);
+  resolveValueSetForVSConstraint(vsConstraint) {
+    let vs = vsConstraint.valueset().getText();
+    if (vsConstraint.valueset().PATH_URL()) {
+      const [path, name] =  vsConstraint.valueset().PATH_URL().getText().split('/', 2);
       const resolution = this._preprocessedData.resolvePath(path, this._currentNs, ...this._usesNs);
       if (resolution.error) {
         logger.error(resolution.error);
@@ -313,8 +296,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       if (resolution.url) {
         vs = `${resolution.url}/${name}`;
       }
-    } else if (codeFromVS.valueset().simpleName()) {
-      const name = codeFromVS.valueset().simpleName().getText();
+    } else if (vsConstraint.valueset().simpleName()) {
+      const name = vsConstraint.valueset().simpleName().getText();
       // Look it up in this namespace's value set definitions
       let found = false;
       for (const ns of [this._currentNs, ...this._usesNs]) {
@@ -329,9 +312,9 @@ class DataElementImporter extends SHRDataElementParserListener {
         logger.error('Unable to resolve value set reference: %s', name);
         vs = `urn:tbd:${name}`;
       }
-    } else if (codeFromVS.valueset().tbd()) {
-      if (codeFromVS.valueset().tbd().STRING()) {
-        vs = `urn:tbd:${stripDelimitersFromToken(codeFromVS.valueset().tbd().STRING())}`;
+    } else if (vsConstraint.valueset().tbd()) {
+      if (vsConstraint.valueset().tbd().STRING()) {
+        vs = `urn:tbd:${stripDelimitersFromToken(vsConstraint.valueset().tbd().STRING())}`;
       } else {
         vs = 'urn:tbd';
       }
@@ -339,11 +322,11 @@ class DataElementImporter extends SHRDataElementParserListener {
     return vs;
   }
 
-  resolveCodeFromVSBindingStrength(codeFromVS) {
-    if (codeFromVS.bindingInfix()) {
-      const bindingCtx = codeFromVS.bindingInfix();
+  resolveBindingStrengthForVSConstraint(vsConstraint) {
+    if (vsConstraint.bindingInfix()) {
+      const bindingCtx = vsConstraint.bindingInfix();
       if (bindingCtx.KW_MUST_BE()) {
-        return codeFromVS.KW_IF_COVERED() ? EXTENSIBLE : REQUIRED;
+        return vsConstraint.KW_IF_COVERED() ? EXTENSIBLE : REQUIRED;
       } else if (bindingCtx.KW_SHOULD_BE()) {
         return PREFERRED;
       } else if (bindingCtx.KW_COULD_BE()) {

--- a/lib/parsers/SHRDataElementParser.js
+++ b/lib/parsers/SHRDataElementParser.js
@@ -23,31 +23,31 @@ var serializedATN = ["\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd",
     "\3\21\5\21\u00be\n\21\3\21\7\21\u00c1\n\21\f\21\16\21\u00c4\13\21\3",
     "\22\3\22\5\22\u00c8\n\22\3\22\5\22\u00cb\n\22\3\22\3\22\3\22\7\22\u00d0",
     "\n\22\f\22\16\22\u00d3\13\22\3\22\5\22\u00d6\n\22\3\23\3\23\3\23\3\23",
-    "\3\23\3\23\5\23\u00de\n\23\3\24\5\24\u00e1\n\24\3\24\5\24\u00e4\n\24",
-    "\3\24\3\24\3\24\7\24\u00e9\n\24\f\24\16\24\u00ec\13\24\3\24\5\24\u00ef",
-    "\n\24\3\25\3\25\3\25\3\25\5\25\u00f5\n\25\3\26\3\26\3\26\5\26\u00fa",
-    "\n\26\3\27\3\27\3\27\5\27\u00ff\n\27\3\30\3\30\3\30\7\30\u0104\n\30",
-    "\f\30\16\30\u0107\13\30\3\31\3\31\3\31\3\32\3\32\3\32\3\32\3\33\3\33",
-    "\3\34\3\34\3\35\3\35\3\36\3\36\5\36\u0118\n\36\3\37\3\37\3\37\3\37\3",
-    "\37\3 \3 \5 \u0121\n \3!\3!\3!\5!\u0126\n!\3\"\3\"\5\"\u012a\n\"\3#",
-    "\3#\5#\u012e\n#\3#\5#\u0131\n#\3#\3#\3#\5#\u0136\n#\3$\3$\3%\3%\3%\5",
-    "%\u013d\n%\3%\5%\u0140\n%\3&\3&\3&\6&\u0145\n&\r&\16&\u0146\3&\3&\5",
-    "&\u014b\n&\3&\3&\7&\u014f\n&\f&\16&\u0152\13&\3&\3&\5&\u0156\n&\3\'",
-    "\3\'\3\'\3\'\3\'\3\'\5\'\u015e\n\'\3(\3(\3(\3)\3)\3)\3*\3*\6*\u0168",
-    "\n*\r*\16*\u0169\3+\3+\3+\3,\3,\3,\5,\u0172\n,\3-\3-\3-\3-\3.\3.\3.",
-    "\3.\3.\5.\u017d\n.\3/\3/\3\60\3\60\3\60\3\60\3\61\3\61\5\61\u0187\n",
-    "\61\3\62\3\62\5\62\u018b\n\62\3\62\2\2\63\2\4\6\b\n\f\16\20\22\24\26",
-    "\30\32\34\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`b\2\n\4\2\'\'",
-    ")*\3\2@A\3\2>?\3\2\22\24\3\2\34\35\3\2\31\32\3\2,<\4\2##==\u0199\2d",
-    "\3\2\2\2\4s\3\2\2\2\6y\3\2\2\2\b\u0083\3\2\2\2\n\u0087\3\2\2\2\f\u008d",
-    "\3\2\2\2\16\u0091\3\2\2\2\20\u0099\3\2\2\2\22\u009e\3\2\2\2\24\u00a0",
-    "\3\2\2\2\26\u00a6\3\2\2\2\30\u00a9\3\2\2\2\32\u00af\3\2\2\2\34\u00b3",
-    "\3\2\2\2\36\u00ba\3\2\2\2 \u00bd\3\2\2\2\"\u00c5\3\2\2\2$\u00dd\3\2",
-    "\2\2&\u00e0\3\2\2\2(\u00f4\3\2\2\2*\u00f6\3\2\2\2,\u00fb\3\2\2\2.\u0100",
-    "\3\2\2\2\60\u0108\3\2\2\2\62\u010b\3\2\2\2\64\u010f\3\2\2\2\66\u0111",
-    "\3\2\2\28\u0113\3\2\2\2:\u0117\3\2\2\2<\u0119\3\2\2\2>\u011e\3\2\2\2",
-    "@\u0125\3\2\2\2B\u0129\3\2\2\2D\u012d\3\2\2\2F\u0137\3\2\2\2H\u013c",
-    "\3\2\2\2J\u0141\3\2\2\2L\u015d\3\2\2\2N\u015f\3\2\2\2P\u0162\3\2\2\2",
+    "\3\23\5\23\u00dd\n\23\3\24\5\24\u00e0\n\24\3\24\5\24\u00e3\n\24\3\24",
+    "\3\24\3\24\7\24\u00e8\n\24\f\24\16\24\u00eb\13\24\3\24\5\24\u00ee\n",
+    "\24\3\25\3\25\3\25\3\25\5\25\u00f4\n\25\3\26\3\26\3\26\5\26\u00f9\n",
+    "\26\3\27\3\27\3\27\5\27\u00fe\n\27\3\30\3\30\3\30\7\30\u0103\n\30\f",
+    "\30\16\30\u0106\13\30\3\31\3\31\3\31\3\32\3\32\3\32\3\32\3\33\3\33\3",
+    "\34\3\34\3\35\3\35\3\36\3\36\5\36\u0117\n\36\3\37\3\37\3\37\3\37\3\37",
+    "\3 \3 \5 \u0120\n \3!\3!\3!\5!\u0125\n!\3\"\3\"\5\"\u0129\n\"\3#\3#",
+    "\3$\3$\3$\5$\u0130\n$\3$\5$\u0133\n$\3%\3%\3%\6%\u0138\n%\r%\16%\u0139",
+    "\3%\3%\5%\u013e\n%\3%\3%\7%\u0142\n%\f%\16%\u0145\13%\3%\3%\5%\u0149",
+    "\n%\3&\3&\3&\3&\3&\3&\5&\u0151\n&\3\'\3\'\3\'\5\'\u0156\n\'\3(\5(\u0159",
+    "\n(\3(\5(\u015c\n(\3(\3(\3(\5(\u0161\n(\3)\3)\3)\3*\3*\6*\u0168\n*\r",
+    "*\16*\u0169\3+\3+\3+\3,\3,\3,\5,\u0172\n,\3-\3-\3-\3-\3.\3.\3.\3.\3",
+    ".\5.\u017d\n.\3/\3/\3\60\3\60\3\60\3\60\3\61\3\61\5\61\u0187\n\61\3",
+    "\62\3\62\5\62\u018b\n\62\3\62\2\2\63\2\4\6\b\n\f\16\20\22\24\26\30\32",
+    "\34\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`b\2\n\4\2\'\')*\3\2",
+    "@A\3\2>?\3\2\22\24\3\2\34\35\3\2\31\32\3\2,<\4\2##==\u0199\2d\3\2\2",
+    "\2\4s\3\2\2\2\6y\3\2\2\2\b\u0083\3\2\2\2\n\u0087\3\2\2\2\f\u008d\3\2",
+    "\2\2\16\u0091\3\2\2\2\20\u0099\3\2\2\2\22\u009e\3\2\2\2\24\u00a0\3\2",
+    "\2\2\26\u00a6\3\2\2\2\30\u00a9\3\2\2\2\32\u00af\3\2\2\2\34\u00b3\3\2",
+    "\2\2\36\u00ba\3\2\2\2 \u00bd\3\2\2\2\"\u00c5\3\2\2\2$\u00dc\3\2\2\2",
+    "&\u00df\3\2\2\2(\u00f3\3\2\2\2*\u00f5\3\2\2\2,\u00fa\3\2\2\2.\u00ff",
+    "\3\2\2\2\60\u0107\3\2\2\2\62\u010a\3\2\2\2\64\u010e\3\2\2\2\66\u0110",
+    "\3\2\2\28\u0112\3\2\2\2:\u0116\3\2\2\2<\u0118\3\2\2\2>\u011d\3\2\2\2",
+    "@\u0124\3\2\2\2B\u0128\3\2\2\2D\u012a\3\2\2\2F\u012f\3\2\2\2H\u0134",
+    "\3\2\2\2J\u0150\3\2\2\2L\u0152\3\2\2\2N\u0158\3\2\2\2P\u0162\3\2\2\2",
     "R\u0167\3\2\2\2T\u016b\3\2\2\2V\u016e\3\2\2\2X\u0173\3\2\2\2Z\u017c",
     "\3\2\2\2\\\u017e\3\2\2\2^\u0180\3\2\2\2`\u0184\3\2\2\2b\u0188\3\2\2",
     "\2df\5\4\3\2eg\5\60\31\2fe\3\2\2\2fg\3\2\2\2gi\3\2\2\2hj\5\6\4\2ih\3",
@@ -84,73 +84,73 @@ var serializedATN = ["\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd",
     "\u00d1\5$\23\2\u00cd\u00ce\7\20\2\2\u00ce\u00d0\5$\23\2\u00cf\u00cd",
     "\3\2\2\2\u00d0\u00d3\3\2\2\2\u00d1\u00cf\3\2\2\2\u00d1\u00d2\3\2\2\2",
     "\u00d2\u00d5\3\2\2\2\u00d3\u00d1\3\2\2\2\u00d4\u00d6\7%\2\2\u00d5\u00d4",
-    "\3\2\2\2\u00d5\u00d6\3\2\2\2\u00d6#\3\2\2\2\u00d7\u00de\5:\36\2\u00d8",
-    "\u00de\5<\37\2\u00d9\u00de\5\\/\2\u00da\u00de\5D#\2\u00db\u00de\5H%",
-    "\2\u00dc\u00de\5`\61\2\u00dd\u00d7\3\2\2\2\u00dd\u00d8\3\2\2\2\u00dd",
-    "\u00d9\3\2\2\2\u00dd\u00da\3\2\2\2\u00dd\u00db\3\2\2\2\u00dd\u00dc\3",
-    "\2\2\2\u00de%\3\2\2\2\u00df\u00e1\5^\60\2\u00e0\u00df\3\2\2\2\u00e0",
-    "\u00e1\3\2\2\2\u00e1\u00e3\3\2\2\2\u00e2\u00e4\7$\2\2\u00e3\u00e2\3",
-    "\2\2\2\u00e3\u00e4\3\2\2\2\u00e4\u00e5\3\2\2\2\u00e5\u00ea\5(\25\2\u00e6",
-    "\u00e7\7\20\2\2\u00e7\u00e9\5(\25\2\u00e8\u00e6\3\2\2\2\u00e9\u00ec",
-    "\3\2\2\2\u00ea\u00e8\3\2\2\2\u00ea\u00eb\3\2\2\2\u00eb\u00ee\3\2\2\2",
-    "\u00ec\u00ea\3\2\2\2\u00ed\u00ef\7%\2\2\u00ee\u00ed\3\2\2\2\u00ee\u00ef",
-    "\3\2\2\2\u00ef\'\3\2\2\2\u00f0\u00f5\5:\36\2\u00f1\u00f5\5<\37\2\u00f2",
-    "\u00f5\5H%\2\u00f3\u00f5\5`\61\2\u00f4\u00f0\3\2\2\2\u00f4\u00f1\3\2",
-    "\2\2\u00f4\u00f2\3\2\2\2\u00f4\u00f3\3\2\2\2\u00f5)\3\2\2\2\u00f6\u00f9",
-    "\7\13\2\2\u00f7\u00fa\5:\36\2\u00f8\u00fa\5`\61\2\u00f9\u00f7\3\2\2",
-    "\2\u00f9\u00f8\3\2\2\2\u00fa+\3\2\2\2\u00fb\u00fe\7\r\2\2\u00fc\u00ff",
-    "\5.\30\2\u00fd\u00ff\5`\61\2\u00fe\u00fc\3\2\2\2\u00fe\u00fd\3\2\2\2",
-    "\u00ff-\3\2\2\2\u0100\u0105\5@!\2\u0101\u0102\7\"\2\2\u0102\u0104\5",
-    "@!\2\u0103\u0101\3\2\2\2\u0104\u0107\3\2\2\2\u0105\u0103\3\2\2\2\u0105",
-    "\u0106\3\2\2\2\u0106/\3\2\2\2\u0107\u0105\3\2\2\2\u0108\u0109\7\16\2",
-    "\2\u0109\u010a\7C\2\2\u010a\61\3\2\2\2\u010b\u010c\7=\2\2\u010c\u010d",
-    "\7 \2\2\u010d\u010e\7=\2\2\u010e\63\3\2\2\2\u010f\u0110\t\3\2\2\u0110",
-    "\65\3\2\2\2\u0111\u0112\t\4\2\2\u0112\67\3\2\2\2\u0113\u0114\7B\2\2",
-    "\u01149\3\2\2\2\u0115\u0118\5\66\34\2\u0116\u0118\58\35\2\u0117\u0115",
-    "\3\2\2\2\u0117\u0116\3\2\2\2\u0118;\3\2\2\2\u0119\u011a\7\17\2\2\u011a",
-    "\u011b\7$\2\2\u011b\u011c\5:\36\2\u011c\u011d\7%\2\2\u011d=\3\2\2\2",
-    "\u011e\u0120\7+\2\2\u011f\u0121\7C\2\2\u0120\u011f\3\2\2\2\u0120\u0121",
-    "\3\2\2\2\u0121?\3\2\2\2\u0122\u0123\7>\2\2\u0123\u0126\5> \2\u0124\u0126",
-    "\5b\62\2\u0125\u0122\3\2\2\2\u0125\u0124\3\2\2\2\u0126A\3\2\2\2\u0127",
-    "\u012a\5@!\2\u0128\u012a\5> \2\u0129\u0127\3\2\2\2\u0129\u0128\3\2\2",
-    "\2\u012aC\3\2\2\2\u012b\u012e\7\66\2\2\u012c\u012e\5:\36\2\u012d\u012b",
-    "\3\2\2\2\u012d\u012c\3\2\2\2\u012e\u0130\3\2\2\2\u012f\u0131\5F$\2\u0130",
-    "\u012f\3\2\2\2\u0130\u0131\3\2\2\2\u0131\u0132\3\2\2\2\u0132\u0133\7",
-    "\26\2\2\u0133\u0135\5Z.\2\u0134\u0136\7\25\2\2\u0135\u0134\3\2\2\2\u0135",
-    "\u0136\3\2\2\2\u0136E\3\2\2\2\u0137\u0138\t\5\2\2\u0138G\3\2\2\2\u0139",
-    "\u013d\5:\36\2\u013a\u013d\5J&\2\u013b\u013d\5\\/\2\u013c\u0139\3\2",
-    "\2\2\u013c\u013a\3\2\2\2\u013c\u013b\3\2\2\2\u013d\u013f\3\2\2\2\u013e",
-    "\u0140\5L\'\2\u013f\u013e\3\2\2\2\u013f\u0140\3\2\2\2\u0140I\3\2\2\2",
-    "\u0141\u0155\5:\36\2\u0142\u0143\7 \2\2\u0143\u0145\5\66\34\2\u0144",
-    "\u0142\3\2\2\2\u0145\u0146\3\2\2\2\u0146\u0144\3\2\2\2\u0146\u0147\3",
-    "\2\2\2\u0147\u014a\3\2\2\2\u0148\u0149\7 \2\2\u0149\u014b\5\\/\2\u014a",
-    "\u0148\3\2\2\2\u014a\u014b\3\2\2\2\u014b\u0156\3\2\2\2\u014c\u014d\7",
-    " \2\2\u014d\u014f\5\66\34\2\u014e\u014c\3\2\2\2\u014f\u0152\3\2\2\2",
-    "\u0150\u014e\3\2\2\2\u0150\u0151\3\2\2\2\u0151\u0153\3\2\2\2\u0152\u0150",
-    "\3\2\2\2\u0153\u0154\7 \2\2\u0154\u0156\5\\/\2\u0155\u0144\3\2\2\2\u0155",
-    "\u0150\3\2\2\2\u0156K\3\2\2\2\u0157\u015e\5N(\2\u0158\u015e\5P)\2\u0159",
-    "\u015e\5R*\2\u015a\u015e\5T+\2\u015b\u015e\5V,\2\u015c\u015e\5X-\2\u015d",
-    "\u0157\3\2\2\2\u015d\u0158\3\2\2\2\u015d\u0159\3\2\2\2\u015d\u015a\3",
-    "\2\2\2\u015d\u015b\3\2\2\2\u015d\u015c\3\2\2\2\u015eM\3\2\2\2\u015f",
-    "\u0160\7\21\2\2\u0160\u0161\5D#\2\u0161O\3\2\2\2\u0162\u0163\7\30\2",
-    "\2\u0163\u0164\5B\"\2\u0164Q\3\2\2\2\u0165\u0166\7\33\2\2\u0166\u0168",
-    "\5B\"\2\u0167\u0165\3\2\2\2\u0168\u0169\3\2\2\2\u0169\u0167\3\2\2\2",
-    "\u0169\u016a\3\2\2\2\u016aS\3\2\2\2\u016b\u016c\7\30\2\2\u016c\u016d",
-    "\t\6\2\2\u016dU\3\2\2\2\u016e\u0171\t\7\2\2\u016f\u0172\5:\36\2\u0170",
-    "\u0172\5`\61\2\u0171\u016f\3\2\2\2\u0171\u0170\3\2\2\2\u0172W\3\2\2",
-    "\2\u0173\u0174\7\21\2\2\u0174\u0175\7\27\2\2\u0175\u0176\5@!\2\u0176",
-    "Y\3\2\2\2\u0177\u017d\7\'\2\2\u0178\u017d\7(\2\2\u0179\u017d\7)\2\2",
-    "\u017a\u017d\5\66\34\2\u017b\u017d\5`\61\2\u017c\u0177\3\2\2\2\u017c",
-    "\u0178\3\2\2\2\u017c\u0179\3\2\2\2\u017c\u017a\3\2\2\2\u017c\u017b\3",
-    "\2\2\2\u017d[\3\2\2\2\u017e\u017f\t\b\2\2\u017f]\3\2\2\2\u0180\u0181",
-    "\7=\2\2\u0181\u0182\7&\2\2\u0182\u0183\t\t\2\2\u0183_\3\2\2\2\u0184",
-    "\u0186\7\36\2\2\u0185\u0187\7C\2\2\u0186\u0185\3\2\2\2\u0186\u0187\3",
-    "\2\2\2\u0187a\3\2\2\2\u0188\u018a\7\37\2\2\u0189\u018b\7C\2\2\u018a",
-    "\u0189\3\2\2\2\u018a\u018b\3\2\2\2\u018bc\3\2\2\2\61filo\177\u0085\u008f",
-    "\u0099\u009e\u00a2\u00ab\u00b5\u00ba\u00bd\u00c2\u00c7\u00ca\u00d1\u00d5",
-    "\u00dd\u00e0\u00e3\u00ea\u00ee\u00f4\u00f9\u00fe\u0105\u0117\u0120\u0125",
-    "\u0129\u012d\u0130\u0135\u013c\u013f\u0146\u014a\u0150\u0155\u015d\u0169",
-    "\u0171\u017c\u0186\u018a"].join("");
+    "\3\2\2\2\u00d5\u00d6\3\2\2\2\u00d6#\3\2\2\2\u00d7\u00dd\5:\36\2\u00d8",
+    "\u00dd\5<\37\2\u00d9\u00dd\5\\/\2\u00da\u00dd\5F$\2\u00db\u00dd\5`\61",
+    "\2\u00dc\u00d7\3\2\2\2\u00dc\u00d8\3\2\2\2\u00dc\u00d9\3\2\2\2\u00dc",
+    "\u00da\3\2\2\2\u00dc\u00db\3\2\2\2\u00dd%\3\2\2\2\u00de\u00e0\5^\60",
+    "\2\u00df\u00de\3\2\2\2\u00df\u00e0\3\2\2\2\u00e0\u00e2\3\2\2\2\u00e1",
+    "\u00e3\7$\2\2\u00e2\u00e1\3\2\2\2\u00e2\u00e3\3\2\2\2\u00e3\u00e4\3",
+    "\2\2\2\u00e4\u00e9\5(\25\2\u00e5\u00e6\7\20\2\2\u00e6\u00e8\5(\25\2",
+    "\u00e7\u00e5\3\2\2\2\u00e8\u00eb\3\2\2\2\u00e9\u00e7\3\2\2\2\u00e9\u00ea",
+    "\3\2\2\2\u00ea\u00ed\3\2\2\2\u00eb\u00e9\3\2\2\2\u00ec\u00ee\7%\2\2",
+    "\u00ed\u00ec\3\2\2\2\u00ed\u00ee\3\2\2\2\u00ee\'\3\2\2\2\u00ef\u00f4",
+    "\5:\36\2\u00f0\u00f4\5<\37\2\u00f1\u00f4\5F$\2\u00f2\u00f4\5`\61\2\u00f3",
+    "\u00ef\3\2\2\2\u00f3\u00f0\3\2\2\2\u00f3\u00f1\3\2\2\2\u00f3\u00f2\3",
+    "\2\2\2\u00f4)\3\2\2\2\u00f5\u00f8\7\13\2\2\u00f6\u00f9\5:\36\2\u00f7",
+    "\u00f9\5`\61\2\u00f8\u00f6\3\2\2\2\u00f8\u00f7\3\2\2\2\u00f9+\3\2\2",
+    "\2\u00fa\u00fd\7\r\2\2\u00fb\u00fe\5.\30\2\u00fc\u00fe\5`\61\2\u00fd",
+    "\u00fb\3\2\2\2\u00fd\u00fc\3\2\2\2\u00fe-\3\2\2\2\u00ff\u0104\5@!\2",
+    "\u0100\u0101\7\"\2\2\u0101\u0103\5@!\2\u0102\u0100\3\2\2\2\u0103\u0106",
+    "\3\2\2\2\u0104\u0102\3\2\2\2\u0104\u0105\3\2\2\2\u0105/\3\2\2\2\u0106",
+    "\u0104\3\2\2\2\u0107\u0108\7\16\2\2\u0108\u0109\7C\2\2\u0109\61\3\2",
+    "\2\2\u010a\u010b\7=\2\2\u010b\u010c\7 \2\2\u010c\u010d\7=\2\2\u010d",
+    "\63\3\2\2\2\u010e\u010f\t\3\2\2\u010f\65\3\2\2\2\u0110\u0111\t\4\2\2",
+    "\u0111\67\3\2\2\2\u0112\u0113\7B\2\2\u01139\3\2\2\2\u0114\u0117\5\66",
+    "\34\2\u0115\u0117\58\35\2\u0116\u0114\3\2\2\2\u0116\u0115\3\2\2\2\u0117",
+    ";\3\2\2\2\u0118\u0119\7\17\2\2\u0119\u011a\7$\2\2\u011a\u011b\5:\36",
+    "\2\u011b\u011c\7%\2\2\u011c=\3\2\2\2\u011d\u011f\7+\2\2\u011e\u0120",
+    "\7C\2\2\u011f\u011e\3\2\2\2\u011f\u0120\3\2\2\2\u0120?\3\2\2\2\u0121",
+    "\u0122\7>\2\2\u0122\u0125\5> \2\u0123\u0125\5b\62\2\u0124\u0121\3\2",
+    "\2\2\u0124\u0123\3\2\2\2\u0125A\3\2\2\2\u0126\u0129\5@!\2\u0127\u0129",
+    "\5> \2\u0128\u0126\3\2\2\2\u0128\u0127\3\2\2\2\u0129C\3\2\2\2\u012a",
+    "\u012b\t\5\2\2\u012bE\3\2\2\2\u012c\u0130\5:\36\2\u012d\u0130\5H%\2",
+    "\u012e\u0130\5\\/\2\u012f\u012c\3\2\2\2\u012f\u012d\3\2\2\2\u012f\u012e",
+    "\3\2\2\2\u0130\u0132\3\2\2\2\u0131\u0133\5J&\2\u0132\u0131\3\2\2\2\u0132",
+    "\u0133\3\2\2\2\u0133G\3\2\2\2\u0134\u0148\5:\36\2\u0135\u0136\7 \2\2",
+    "\u0136\u0138\5\66\34\2\u0137\u0135\3\2\2\2\u0138\u0139\3\2\2\2\u0139",
+    "\u0137\3\2\2\2\u0139\u013a\3\2\2\2\u013a\u013d\3\2\2\2\u013b\u013c\7",
+    " \2\2\u013c\u013e\5\\/\2\u013d\u013b\3\2\2\2\u013d\u013e\3\2\2\2\u013e",
+    "\u0149\3\2\2\2\u013f\u0140\7 \2\2\u0140\u0142\5\66\34\2\u0141\u013f",
+    "\3\2\2\2\u0142\u0145\3\2\2\2\u0143\u0141\3\2\2\2\u0143\u0144\3\2\2\2",
+    "\u0144\u0146\3\2\2\2\u0145\u0143\3\2\2\2\u0146\u0147\7 \2\2\u0147\u0149",
+    "\5\\/\2\u0148\u0137\3\2\2\2\u0148\u0143\3\2\2\2\u0149I\3\2\2\2\u014a",
+    "\u0151\5N(\2\u014b\u0151\5P)\2\u014c\u0151\5R*\2\u014d\u0151\5T+\2\u014e",
+    "\u0151\5V,\2\u014f\u0151\5X-\2\u0150\u014a\3\2\2\2\u0150\u014b\3\2\2",
+    "\2\u0150\u014c\3\2\2\2\u0150\u014d\3\2\2\2\u0150\u014e\3\2\2\2\u0150",
+    "\u014f\3\2\2\2\u0151K\3\2\2\2\u0152\u0155\7\21\2\2\u0153\u0156\7\66",
+    "\2\2\u0154\u0156\5:\36\2\u0155\u0153\3\2\2\2\u0155\u0154\3\2\2\2\u0156",
+    "M\3\2\2\2\u0157\u0159\5L\'\2\u0158\u0157\3\2\2\2\u0158\u0159\3\2\2\2",
+    "\u0159\u015b\3\2\2\2\u015a\u015c\5D#\2\u015b\u015a\3\2\2\2\u015b\u015c",
+    "\3\2\2\2\u015c\u015d\3\2\2\2\u015d\u015e\7\26\2\2\u015e\u0160\5Z.\2",
+    "\u015f\u0161\7\25\2\2\u0160\u015f\3\2\2\2\u0160\u0161\3\2\2\2\u0161",
+    "O\3\2\2\2\u0162\u0163\7\30\2\2\u0163\u0164\5B\"\2\u0164Q\3\2\2\2\u0165",
+    "\u0166\7\33\2\2\u0166\u0168\5B\"\2\u0167\u0165\3\2\2\2\u0168\u0169\3",
+    "\2\2\2\u0169\u0167\3\2\2\2\u0169\u016a\3\2\2\2\u016aS\3\2\2\2\u016b",
+    "\u016c\7\30\2\2\u016c\u016d\t\6\2\2\u016dU\3\2\2\2\u016e\u0171\t\7\2",
+    "\2\u016f\u0172\5:\36\2\u0170\u0172\5`\61\2\u0171\u016f\3\2\2\2\u0171",
+    "\u0170\3\2\2\2\u0172W\3\2\2\2\u0173\u0174\7\21\2\2\u0174\u0175\7\27",
+    "\2\2\u0175\u0176\5@!\2\u0176Y\3\2\2\2\u0177\u017d\7\'\2\2\u0178\u017d",
+    "\7(\2\2\u0179\u017d\7)\2\2\u017a\u017d\5\66\34\2\u017b\u017d\5`\61\2",
+    "\u017c\u0177\3\2\2\2\u017c\u0178\3\2\2\2\u017c\u0179\3\2\2\2\u017c\u017a",
+    "\3\2\2\2\u017c\u017b\3\2\2\2\u017d[\3\2\2\2\u017e\u017f\t\b\2\2\u017f",
+    "]\3\2\2\2\u0180\u0181\7=\2\2\u0181\u0182\7&\2\2\u0182\u0183\t\t\2\2",
+    "\u0183_\3\2\2\2\u0184\u0186\7\36\2\2\u0185\u0187\7C\2\2\u0186\u0185",
+    "\3\2\2\2\u0186\u0187\3\2\2\2\u0187a\3\2\2\2\u0188\u018a\7\37\2\2\u0189",
+    "\u018b\7C\2\2\u018a\u0189\3\2\2\2\u018a\u018b\3\2\2\2\u018bc\3\2\2\2",
+    "\62filo\177\u0085\u008f\u0099\u009e\u00a2\u00ab\u00b5\u00ba\u00bd\u00c2",
+    "\u00c7\u00ca\u00d1\u00d5\u00dc\u00df\u00e2\u00e9\u00ed\u00f3\u00f8\u00fd",
+    "\u0104\u0116\u011f\u0124\u0128\u012f\u0132\u0139\u013d\u0143\u0148\u0150",
+    "\u0155\u0158\u015b\u0160\u0169\u0171\u017c\u0186\u018a"].join("");
 
 
 var atn = new antlr4.atn.ATNDeserializer().deserialize(serializedATN);
@@ -198,9 +198,9 @@ var ruleNames =  [ "doc", "docHeader", "usesStatement", "pathDefs", "pathDef",
                    "field", "fieldType", "basedOnProp", "conceptProp", "concepts", 
                    "descriptionProp", "version", "namespace", "simpleName", 
                    "fullyQualifiedName", "simpleOrFQName", "ref", "code", 
-                   "fullyQualifiedCode", "codeOrFQCode", "codeFromVS", "bindingInfix", 
+                   "fullyQualifiedCode", "codeOrFQCode", "bindingInfix", 
                    "elementWithConstraint", "elementPath", "elementConstraint", 
-                   "elementCodeVSConstraint", "elementCodeValueConstraint", 
+                   "legacyWithCode", "elementCodeVSConstraint", "elementCodeValueConstraint", 
                    "elementIncludesCodeValueConstraint", "elementBooleanConstraint", 
                    "elementTypeConstraint", "elementWithUnitsConstraint", 
                    "valueset", "primitive", "count", "tbd", "tbdCode" ];
@@ -327,11 +327,11 @@ SHRDataElementParser.RULE_ref = 29;
 SHRDataElementParser.RULE_code = 30;
 SHRDataElementParser.RULE_fullyQualifiedCode = 31;
 SHRDataElementParser.RULE_codeOrFQCode = 32;
-SHRDataElementParser.RULE_codeFromVS = 33;
-SHRDataElementParser.RULE_bindingInfix = 34;
-SHRDataElementParser.RULE_elementWithConstraint = 35;
-SHRDataElementParser.RULE_elementPath = 36;
-SHRDataElementParser.RULE_elementConstraint = 37;
+SHRDataElementParser.RULE_bindingInfix = 33;
+SHRDataElementParser.RULE_elementWithConstraint = 34;
+SHRDataElementParser.RULE_elementPath = 35;
+SHRDataElementParser.RULE_elementConstraint = 36;
+SHRDataElementParser.RULE_legacyWithCode = 37;
 SHRDataElementParser.RULE_elementCodeVSConstraint = 38;
 SHRDataElementParser.RULE_elementCodeValueConstraint = 39;
 SHRDataElementParser.RULE_elementIncludesCodeValueConstraint = 40;
@@ -1926,10 +1926,6 @@ ValueTypeContext.prototype.primitive = function() {
     return this.getTypedRuleContext(PrimitiveContext,0);
 };
 
-ValueTypeContext.prototype.codeFromVS = function() {
-    return this.getTypedRuleContext(CodeFromVSContext,0);
-};
-
 ValueTypeContext.prototype.elementWithConstraint = function() {
     return this.getTypedRuleContext(ElementWithConstraintContext,0);
 };
@@ -1968,7 +1964,7 @@ SHRDataElementParser.prototype.valueType = function() {
     var localctx = new ValueTypeContext(this, this._ctx, this.state);
     this.enterRule(localctx, 34, SHRDataElementParser.RULE_valueType);
     try {
-        this.state = 219;
+        this.state = 218;
         var la_ = this._interp.adaptivePredict(this._input,19,this._ctx);
         switch(la_) {
         case 1:
@@ -1992,18 +1988,12 @@ SHRDataElementParser.prototype.valueType = function() {
         case 4:
             this.enterOuterAlt(localctx, 4);
             this.state = 216;
-            this.codeFromVS();
+            this.elementWithConstraint();
             break;
 
         case 5:
             this.enterOuterAlt(localctx, 5);
             this.state = 217;
-            this.elementWithConstraint();
-            break;
-
-        case 6:
-            this.enterOuterAlt(localctx, 6);
-            this.state = 218;
             this.tbd();
             break;
 
@@ -2105,38 +2095,38 @@ SHRDataElementParser.prototype.field = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 222;
+        this.state = 221;
         _la = this._input.LA(1);
         if(_la===SHRDataElementParser.WHOLE_NUMBER) {
-            this.state = 221;
+            this.state = 220;
             this.count();
         }
 
-        this.state = 225;
+        this.state = 224;
         _la = this._input.LA(1);
         if(_la===SHRDataElementParser.OPEN_PAREN) {
-            this.state = 224;
+            this.state = 223;
             this.match(SHRDataElementParser.OPEN_PAREN);
         }
 
-        this.state = 227;
+        this.state = 226;
         this.fieldType();
-        this.state = 232;
+        this.state = 231;
         this._errHandler.sync(this);
         _la = this._input.LA(1);
         while(_la===SHRDataElementParser.KW_OR) {
-            this.state = 228;
+            this.state = 227;
             this.match(SHRDataElementParser.KW_OR);
-            this.state = 229;
+            this.state = 228;
             this.fieldType();
-            this.state = 234;
+            this.state = 233;
             this._errHandler.sync(this);
             _la = this._input.LA(1);
         }
-        this.state = 236;
+        this.state = 235;
         _la = this._input.LA(1);
         if(_la===SHRDataElementParser.CLOSE_PAREN) {
-            this.state = 235;
+            this.state = 234;
             this.match(SHRDataElementParser.CLOSE_PAREN);
         }
 
@@ -2216,30 +2206,30 @@ SHRDataElementParser.prototype.fieldType = function() {
     var localctx = new FieldTypeContext(this, this._ctx, this.state);
     this.enterRule(localctx, 38, SHRDataElementParser.RULE_fieldType);
     try {
-        this.state = 242;
+        this.state = 241;
         var la_ = this._interp.adaptivePredict(this._input,24,this._ctx);
         switch(la_) {
         case 1:
             this.enterOuterAlt(localctx, 1);
-            this.state = 238;
+            this.state = 237;
             this.simpleOrFQName();
             break;
 
         case 2:
             this.enterOuterAlt(localctx, 2);
-            this.state = 239;
+            this.state = 238;
             this.ref();
             break;
 
         case 3:
             this.enterOuterAlt(localctx, 3);
-            this.state = 240;
+            this.state = 239;
             this.elementWithConstraint();
             break;
 
         case 4:
             this.enterOuterAlt(localctx, 4);
-            this.state = 241;
+            this.state = 240;
             this.tbd();
             break;
 
@@ -2317,18 +2307,18 @@ SHRDataElementParser.prototype.basedOnProp = function() {
     this.enterRule(localctx, 40, SHRDataElementParser.RULE_basedOnProp);
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 244;
+        this.state = 243;
         this.match(SHRDataElementParser.KW_BASED_ON);
-        this.state = 247;
+        this.state = 246;
         switch(this._input.LA(1)) {
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
         case SHRDataElementParser.DOT_SEPARATED_UW:
-            this.state = 245;
+            this.state = 244;
             this.simpleOrFQName();
             break;
         case SHRDataElementParser.KW_TBD:
-            this.state = 246;
+            this.state = 245;
             this.tbd();
             break;
         default:
@@ -2407,17 +2397,17 @@ SHRDataElementParser.prototype.conceptProp = function() {
     this.enterRule(localctx, 42, SHRDataElementParser.RULE_conceptProp);
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 249;
+        this.state = 248;
         this.match(SHRDataElementParser.KW_CONCEPT);
-        this.state = 252;
+        this.state = 251;
         switch(this._input.LA(1)) {
         case SHRDataElementParser.KW_TBD_CODE:
         case SHRDataElementParser.ALL_CAPS:
-            this.state = 250;
+            this.state = 249;
             this.concepts();
             break;
         case SHRDataElementParser.KW_TBD:
-            this.state = 251;
+            this.state = 250;
             this.tbd();
             break;
         default:
@@ -2508,17 +2498,17 @@ SHRDataElementParser.prototype.concepts = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 254;
+        this.state = 253;
         this.fullyQualifiedCode();
-        this.state = 259;
+        this.state = 258;
         this._errHandler.sync(this);
         _la = this._input.LA(1);
         while(_la===SHRDataElementParser.COMMA) {
-            this.state = 255;
+            this.state = 254;
             this.match(SHRDataElementParser.COMMA);
-            this.state = 256;
+            this.state = 255;
             this.fullyQualifiedCode();
-            this.state = 261;
+            this.state = 260;
             this._errHandler.sync(this);
             _la = this._input.LA(1);
         }
@@ -2591,9 +2581,9 @@ SHRDataElementParser.prototype.descriptionProp = function() {
     this.enterRule(localctx, 46, SHRDataElementParser.RULE_descriptionProp);
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 262;
+        this.state = 261;
         this.match(SHRDataElementParser.KW_DESCRIPTION);
-        this.state = 263;
+        this.state = 262;
         this.match(SHRDataElementParser.STRING);
     } catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
@@ -2672,11 +2662,11 @@ SHRDataElementParser.prototype.version = function() {
     this.enterRule(localctx, 48, SHRDataElementParser.RULE_version);
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 265;
+        this.state = 264;
         this.match(SHRDataElementParser.WHOLE_NUMBER);
-        this.state = 266;
+        this.state = 265;
         this.match(SHRDataElementParser.DOT);
-        this.state = 267;
+        this.state = 266;
         this.match(SHRDataElementParser.WHOLE_NUMBER);
     } catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
@@ -2748,7 +2738,7 @@ SHRDataElementParser.prototype.namespace = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 269;
+        this.state = 268;
         _la = this._input.LA(1);
         if(!(_la===SHRDataElementParser.LOWER_WORD || _la===SHRDataElementParser.DOT_SEPARATED_LW)) {
         this._errHandler.recoverInline(this);
@@ -2826,7 +2816,7 @@ SHRDataElementParser.prototype.simpleName = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 271;
+        this.state = 270;
         _la = this._input.LA(1);
         if(!(_la===SHRDataElementParser.ALL_CAPS || _la===SHRDataElementParser.UPPER_WORD)) {
         this._errHandler.recoverInline(this);
@@ -2899,7 +2889,7 @@ SHRDataElementParser.prototype.fullyQualifiedName = function() {
     this.enterRule(localctx, 54, SHRDataElementParser.RULE_fullyQualifiedName);
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 273;
+        this.state = 272;
         this.match(SHRDataElementParser.DOT_SEPARATED_UW);
     } catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
@@ -2969,17 +2959,17 @@ SHRDataElementParser.prototype.simpleOrFQName = function() {
     var localctx = new SimpleOrFQNameContext(this, this._ctx, this.state);
     this.enterRule(localctx, 56, SHRDataElementParser.RULE_simpleOrFQName);
     try {
-        this.state = 277;
+        this.state = 276;
         switch(this._input.LA(1)) {
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
             this.enterOuterAlt(localctx, 1);
-            this.state = 275;
+            this.state = 274;
             this.simpleName();
             break;
         case SHRDataElementParser.DOT_SEPARATED_UW:
             this.enterOuterAlt(localctx, 2);
-            this.state = 276;
+            this.state = 275;
             this.fullyQualifiedName();
             break;
         default:
@@ -3062,13 +3052,13 @@ SHRDataElementParser.prototype.ref = function() {
     this.enterRule(localctx, 58, SHRDataElementParser.RULE_ref);
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 279;
+        this.state = 278;
         this.match(SHRDataElementParser.KW_REF);
-        this.state = 280;
+        this.state = 279;
         this.match(SHRDataElementParser.OPEN_PAREN);
-        this.state = 281;
+        this.state = 280;
         this.simpleOrFQName();
-        this.state = 282;
+        this.state = 281;
         this.match(SHRDataElementParser.CLOSE_PAREN);
     } catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
@@ -3140,12 +3130,12 @@ SHRDataElementParser.prototype.code = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 284;
+        this.state = 283;
         this.match(SHRDataElementParser.CODE);
-        this.state = 286;
+        this.state = 285;
         _la = this._input.LA(1);
         if(_la===SHRDataElementParser.STRING) {
-            this.state = 285;
+            this.state = 284;
             this.match(SHRDataElementParser.STRING);
         }
 
@@ -3221,18 +3211,18 @@ SHRDataElementParser.prototype.fullyQualifiedCode = function() {
     var localctx = new FullyQualifiedCodeContext(this, this._ctx, this.state);
     this.enterRule(localctx, 62, SHRDataElementParser.RULE_fullyQualifiedCode);
     try {
-        this.state = 291;
+        this.state = 290;
         switch(this._input.LA(1)) {
         case SHRDataElementParser.ALL_CAPS:
             this.enterOuterAlt(localctx, 1);
-            this.state = 288;
+            this.state = 287;
             this.match(SHRDataElementParser.ALL_CAPS);
-            this.state = 289;
+            this.state = 288;
             this.code();
             break;
         case SHRDataElementParser.KW_TBD_CODE:
             this.enterOuterAlt(localctx, 2);
-            this.state = 290;
+            this.state = 289;
             this.tbdCode();
             break;
         default:
@@ -3306,141 +3296,22 @@ SHRDataElementParser.prototype.codeOrFQCode = function() {
     var localctx = new CodeOrFQCodeContext(this, this._ctx, this.state);
     this.enterRule(localctx, 64, SHRDataElementParser.RULE_codeOrFQCode);
     try {
-        this.state = 295;
+        this.state = 294;
         switch(this._input.LA(1)) {
         case SHRDataElementParser.KW_TBD_CODE:
         case SHRDataElementParser.ALL_CAPS:
             this.enterOuterAlt(localctx, 1);
-            this.state = 293;
+            this.state = 292;
             this.fullyQualifiedCode();
             break;
         case SHRDataElementParser.CODE:
             this.enterOuterAlt(localctx, 2);
-            this.state = 294;
+            this.state = 293;
             this.code();
             break;
         default:
             throw new antlr4.error.NoViableAltException(this);
         }
-    } catch (re) {
-    	if(re instanceof antlr4.error.RecognitionException) {
-	        localctx.exception = re;
-	        this._errHandler.reportError(this, re);
-	        this._errHandler.recover(this, re);
-	    } else {
-	    	throw re;
-	    }
-    } finally {
-        this.exitRule();
-    }
-    return localctx;
-};
-
-function CodeFromVSContext(parser, parent, invokingState) {
-	if(parent===undefined) {
-	    parent = null;
-	}
-	if(invokingState===undefined || invokingState===null) {
-		invokingState = -1;
-	}
-	antlr4.ParserRuleContext.call(this, parent, invokingState);
-    this.parser = parser;
-    this.ruleIndex = SHRDataElementParser.RULE_codeFromVS;
-    return this;
-}
-
-CodeFromVSContext.prototype = Object.create(antlr4.ParserRuleContext.prototype);
-CodeFromVSContext.prototype.constructor = CodeFromVSContext;
-
-CodeFromVSContext.prototype.KW_FROM = function() {
-    return this.getToken(SHRDataElementParser.KW_FROM, 0);
-};
-
-CodeFromVSContext.prototype.valueset = function() {
-    return this.getTypedRuleContext(ValuesetContext,0);
-};
-
-CodeFromVSContext.prototype.KW_CODE = function() {
-    return this.getToken(SHRDataElementParser.KW_CODE, 0);
-};
-
-CodeFromVSContext.prototype.simpleOrFQName = function() {
-    return this.getTypedRuleContext(SimpleOrFQNameContext,0);
-};
-
-CodeFromVSContext.prototype.bindingInfix = function() {
-    return this.getTypedRuleContext(BindingInfixContext,0);
-};
-
-CodeFromVSContext.prototype.KW_IF_COVERED = function() {
-    return this.getToken(SHRDataElementParser.KW_IF_COVERED, 0);
-};
-
-CodeFromVSContext.prototype.enterRule = function(listener) {
-    if(listener instanceof SHRDataElementParserListener ) {
-        listener.enterCodeFromVS(this);
-	}
-};
-
-CodeFromVSContext.prototype.exitRule = function(listener) {
-    if(listener instanceof SHRDataElementParserListener ) {
-        listener.exitCodeFromVS(this);
-	}
-};
-
-CodeFromVSContext.prototype.accept = function(visitor) {
-    if ( visitor instanceof SHRDataElementParserVisitor ) {
-        return visitor.visitCodeFromVS(this);
-    } else {
-        return visitor.visitChildren(this);
-    }
-};
-
-
-
-
-SHRDataElementParser.CodeFromVSContext = CodeFromVSContext;
-
-SHRDataElementParser.prototype.codeFromVS = function() {
-
-    var localctx = new CodeFromVSContext(this, this._ctx, this.state);
-    this.enterRule(localctx, 66, SHRDataElementParser.RULE_codeFromVS);
-    var _la = 0; // Token type
-    try {
-        this.enterOuterAlt(localctx, 1);
-        this.state = 299;
-        switch(this._input.LA(1)) {
-        case SHRDataElementParser.KW_CODE:
-            this.state = 297;
-            this.match(SHRDataElementParser.KW_CODE);
-            break;
-        case SHRDataElementParser.ALL_CAPS:
-        case SHRDataElementParser.UPPER_WORD:
-        case SHRDataElementParser.DOT_SEPARATED_UW:
-            this.state = 298;
-            this.simpleOrFQName();
-            break;
-        default:
-            throw new antlr4.error.NoViableAltException(this);
-        }
-        this.state = 302;
-        _la = this._input.LA(1);
-        if((((_la) & ~0x1f) == 0 && ((1 << _la) & ((1 << SHRDataElementParser.KW_MUST_BE) | (1 << SHRDataElementParser.KW_SHOULD_BE) | (1 << SHRDataElementParser.KW_COULD_BE))) !== 0)) {
-            this.state = 301;
-            this.bindingInfix();
-        }
-
-        this.state = 304;
-        this.match(SHRDataElementParser.KW_FROM);
-        this.state = 305;
-        this.valueset();
-        this.state = 307;
-        _la = this._input.LA(1);
-        if(_la===SHRDataElementParser.KW_IF_COVERED) {
-            this.state = 306;
-            this.match(SHRDataElementParser.KW_IF_COVERED);
-        }
-
     } catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
 	        localctx.exception = re;
@@ -3511,11 +3382,11 @@ SHRDataElementParser.BindingInfixContext = BindingInfixContext;
 SHRDataElementParser.prototype.bindingInfix = function() {
 
     var localctx = new BindingInfixContext(this, this._ctx, this.state);
-    this.enterRule(localctx, 68, SHRDataElementParser.RULE_bindingInfix);
+    this.enterRule(localctx, 66, SHRDataElementParser.RULE_bindingInfix);
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 309;
+        this.state = 296;
         _la = this._input.LA(1);
         if(!((((_la) & ~0x1f) == 0 && ((1 << _la) & ((1 << SHRDataElementParser.KW_MUST_BE) | (1 << SHRDataElementParser.KW_SHOULD_BE) | (1 << SHRDataElementParser.KW_COULD_BE))) !== 0))) {
         this._errHandler.recoverInline(this);
@@ -3597,33 +3468,33 @@ SHRDataElementParser.ElementWithConstraintContext = ElementWithConstraintContext
 SHRDataElementParser.prototype.elementWithConstraint = function() {
 
     var localctx = new ElementWithConstraintContext(this, this._ctx, this.state);
-    this.enterRule(localctx, 70, SHRDataElementParser.RULE_elementWithConstraint);
+    this.enterRule(localctx, 68, SHRDataElementParser.RULE_elementWithConstraint);
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 314;
-        var la_ = this._interp.adaptivePredict(this._input,35,this._ctx);
+        this.state = 301;
+        var la_ = this._interp.adaptivePredict(this._input,32,this._ctx);
         switch(la_) {
         case 1:
-            this.state = 311;
+            this.state = 298;
             this.simpleOrFQName();
             break;
 
         case 2:
-            this.state = 312;
+            this.state = 299;
             this.elementPath();
             break;
 
         case 3:
-            this.state = 313;
+            this.state = 300;
             this.primitive();
             break;
 
         }
-        this.state = 317;
+        this.state = 304;
         _la = this._input.LA(1);
-        if((((_la) & ~0x1f) == 0 && ((1 << _la) & ((1 << SHRDataElementParser.KW_WITH) | (1 << SHRDataElementParser.KW_IS) | (1 << SHRDataElementParser.KW_IS_TYPE) | (1 << SHRDataElementParser.KW_VALUE_IS_TYPE) | (1 << SHRDataElementParser.KW_INCLUDES))) !== 0)) {
-            this.state = 316;
+        if((((_la) & ~0x1f) == 0 && ((1 << _la) & ((1 << SHRDataElementParser.KW_WITH) | (1 << SHRDataElementParser.KW_MUST_BE) | (1 << SHRDataElementParser.KW_SHOULD_BE) | (1 << SHRDataElementParser.KW_COULD_BE) | (1 << SHRDataElementParser.KW_FROM) | (1 << SHRDataElementParser.KW_IS) | (1 << SHRDataElementParser.KW_IS_TYPE) | (1 << SHRDataElementParser.KW_VALUE_IS_TYPE) | (1 << SHRDataElementParser.KW_INCLUDES))) !== 0)) {
+            this.state = 303;
             this.elementConstraint();
         }
 
@@ -3716,64 +3587,64 @@ SHRDataElementParser.ElementPathContext = ElementPathContext;
 SHRDataElementParser.prototype.elementPath = function() {
 
     var localctx = new ElementPathContext(this, this._ctx, this.state);
-    this.enterRule(localctx, 72, SHRDataElementParser.RULE_elementPath);
+    this.enterRule(localctx, 70, SHRDataElementParser.RULE_elementPath);
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 319;
+        this.state = 306;
         this.simpleOrFQName();
-        this.state = 339;
-        var la_ = this._interp.adaptivePredict(this._input,40,this._ctx);
+        this.state = 326;
+        var la_ = this._interp.adaptivePredict(this._input,37,this._ctx);
         switch(la_) {
         case 1:
-            this.state = 322; 
+            this.state = 309; 
             this._errHandler.sync(this);
             var _alt = 1;
             do {
             	switch (_alt) {
             	case 1:
-            		this.state = 320;
+            		this.state = 307;
             		this.match(SHRDataElementParser.DOT);
-            		this.state = 321;
+            		this.state = 308;
             		this.simpleName();
             		break;
             	default:
             		throw new antlr4.error.NoViableAltException(this);
             	}
-            	this.state = 324; 
+            	this.state = 311; 
             	this._errHandler.sync(this);
-            	_alt = this._interp.adaptivePredict(this._input,37, this._ctx);
+            	_alt = this._interp.adaptivePredict(this._input,34, this._ctx);
             } while ( _alt!=2 && _alt!=antlr4.atn.ATN.INVALID_ALT_NUMBER );
-            this.state = 328;
+            this.state = 315;
             _la = this._input.LA(1);
             if(_la===SHRDataElementParser.DOT) {
-                this.state = 326;
+                this.state = 313;
                 this.match(SHRDataElementParser.DOT);
-                this.state = 327;
+                this.state = 314;
                 this.primitive();
             }
 
             break;
 
         case 2:
-            this.state = 334;
+            this.state = 321;
             this._errHandler.sync(this);
-            var _alt = this._interp.adaptivePredict(this._input,39,this._ctx)
+            var _alt = this._interp.adaptivePredict(this._input,36,this._ctx)
             while(_alt!=2 && _alt!=antlr4.atn.ATN.INVALID_ALT_NUMBER) {
                 if(_alt===1) {
-                    this.state = 330;
+                    this.state = 317;
                     this.match(SHRDataElementParser.DOT);
-                    this.state = 331;
+                    this.state = 318;
                     this.simpleName(); 
                 }
-                this.state = 336;
+                this.state = 323;
                 this._errHandler.sync(this);
-                _alt = this._interp.adaptivePredict(this._input,39,this._ctx);
+                _alt = this._interp.adaptivePredict(this._input,36,this._ctx);
             }
 
-            this.state = 337;
+            this.state = 324;
             this.match(SHRDataElementParser.DOT);
-            this.state = 338;
+            this.state = 325;
             this.primitive();
             break;
 
@@ -3860,47 +3731,137 @@ SHRDataElementParser.ElementConstraintContext = ElementConstraintContext;
 SHRDataElementParser.prototype.elementConstraint = function() {
 
     var localctx = new ElementConstraintContext(this, this._ctx, this.state);
-    this.enterRule(localctx, 74, SHRDataElementParser.RULE_elementConstraint);
+    this.enterRule(localctx, 72, SHRDataElementParser.RULE_elementConstraint);
     try {
-        this.state = 347;
-        var la_ = this._interp.adaptivePredict(this._input,41,this._ctx);
+        this.state = 334;
+        var la_ = this._interp.adaptivePredict(this._input,38,this._ctx);
         switch(la_) {
         case 1:
             this.enterOuterAlt(localctx, 1);
-            this.state = 341;
+            this.state = 328;
             this.elementCodeVSConstraint();
             break;
 
         case 2:
             this.enterOuterAlt(localctx, 2);
-            this.state = 342;
+            this.state = 329;
             this.elementCodeValueConstraint();
             break;
 
         case 3:
             this.enterOuterAlt(localctx, 3);
-            this.state = 343;
+            this.state = 330;
             this.elementIncludesCodeValueConstraint();
             break;
 
         case 4:
             this.enterOuterAlt(localctx, 4);
-            this.state = 344;
+            this.state = 331;
             this.elementBooleanConstraint();
             break;
 
         case 5:
             this.enterOuterAlt(localctx, 5);
-            this.state = 345;
+            this.state = 332;
             this.elementTypeConstraint();
             break;
 
         case 6:
             this.enterOuterAlt(localctx, 6);
-            this.state = 346;
+            this.state = 333;
             this.elementWithUnitsConstraint();
             break;
 
+        }
+    } catch (re) {
+    	if(re instanceof antlr4.error.RecognitionException) {
+	        localctx.exception = re;
+	        this._errHandler.reportError(this, re);
+	        this._errHandler.recover(this, re);
+	    } else {
+	    	throw re;
+	    }
+    } finally {
+        this.exitRule();
+    }
+    return localctx;
+};
+
+function LegacyWithCodeContext(parser, parent, invokingState) {
+	if(parent===undefined) {
+	    parent = null;
+	}
+	if(invokingState===undefined || invokingState===null) {
+		invokingState = -1;
+	}
+	antlr4.ParserRuleContext.call(this, parent, invokingState);
+    this.parser = parser;
+    this.ruleIndex = SHRDataElementParser.RULE_legacyWithCode;
+    return this;
+}
+
+LegacyWithCodeContext.prototype = Object.create(antlr4.ParserRuleContext.prototype);
+LegacyWithCodeContext.prototype.constructor = LegacyWithCodeContext;
+
+LegacyWithCodeContext.prototype.KW_WITH = function() {
+    return this.getToken(SHRDataElementParser.KW_WITH, 0);
+};
+
+LegacyWithCodeContext.prototype.KW_CODE = function() {
+    return this.getToken(SHRDataElementParser.KW_CODE, 0);
+};
+
+LegacyWithCodeContext.prototype.simpleOrFQName = function() {
+    return this.getTypedRuleContext(SimpleOrFQNameContext,0);
+};
+
+LegacyWithCodeContext.prototype.enterRule = function(listener) {
+    if(listener instanceof SHRDataElementParserListener ) {
+        listener.enterLegacyWithCode(this);
+	}
+};
+
+LegacyWithCodeContext.prototype.exitRule = function(listener) {
+    if(listener instanceof SHRDataElementParserListener ) {
+        listener.exitLegacyWithCode(this);
+	}
+};
+
+LegacyWithCodeContext.prototype.accept = function(visitor) {
+    if ( visitor instanceof SHRDataElementParserVisitor ) {
+        return visitor.visitLegacyWithCode(this);
+    } else {
+        return visitor.visitChildren(this);
+    }
+};
+
+
+
+
+SHRDataElementParser.LegacyWithCodeContext = LegacyWithCodeContext;
+
+SHRDataElementParser.prototype.legacyWithCode = function() {
+
+    var localctx = new LegacyWithCodeContext(this, this._ctx, this.state);
+    this.enterRule(localctx, 74, SHRDataElementParser.RULE_legacyWithCode);
+    try {
+        this.enterOuterAlt(localctx, 1);
+        this.state = 336;
+        this.match(SHRDataElementParser.KW_WITH);
+        this.state = 339;
+        switch(this._input.LA(1)) {
+        case SHRDataElementParser.KW_CODE:
+            this.state = 337;
+            this.match(SHRDataElementParser.KW_CODE);
+            break;
+        case SHRDataElementParser.ALL_CAPS:
+        case SHRDataElementParser.UPPER_WORD:
+        case SHRDataElementParser.DOT_SEPARATED_UW:
+            this.state = 338;
+            this.simpleOrFQName();
+            break;
+        default:
+            throw new antlr4.error.NoViableAltException(this);
         }
     } catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
@@ -3932,12 +3893,24 @@ function ElementCodeVSConstraintContext(parser, parent, invokingState) {
 ElementCodeVSConstraintContext.prototype = Object.create(antlr4.ParserRuleContext.prototype);
 ElementCodeVSConstraintContext.prototype.constructor = ElementCodeVSConstraintContext;
 
-ElementCodeVSConstraintContext.prototype.KW_WITH = function() {
-    return this.getToken(SHRDataElementParser.KW_WITH, 0);
+ElementCodeVSConstraintContext.prototype.KW_FROM = function() {
+    return this.getToken(SHRDataElementParser.KW_FROM, 0);
 };
 
-ElementCodeVSConstraintContext.prototype.codeFromVS = function() {
-    return this.getTypedRuleContext(CodeFromVSContext,0);
+ElementCodeVSConstraintContext.prototype.valueset = function() {
+    return this.getTypedRuleContext(ValuesetContext,0);
+};
+
+ElementCodeVSConstraintContext.prototype.legacyWithCode = function() {
+    return this.getTypedRuleContext(LegacyWithCodeContext,0);
+};
+
+ElementCodeVSConstraintContext.prototype.bindingInfix = function() {
+    return this.getTypedRuleContext(BindingInfixContext,0);
+};
+
+ElementCodeVSConstraintContext.prototype.KW_IF_COVERED = function() {
+    return this.getToken(SHRDataElementParser.KW_IF_COVERED, 0);
 };
 
 ElementCodeVSConstraintContext.prototype.enterRule = function(listener) {
@@ -3969,12 +3942,34 @@ SHRDataElementParser.prototype.elementCodeVSConstraint = function() {
 
     var localctx = new ElementCodeVSConstraintContext(this, this._ctx, this.state);
     this.enterRule(localctx, 76, SHRDataElementParser.RULE_elementCodeVSConstraint);
+    var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 349;
-        this.match(SHRDataElementParser.KW_WITH);
+        this.state = 342;
+        _la = this._input.LA(1);
+        if(_la===SHRDataElementParser.KW_WITH) {
+            this.state = 341;
+            this.legacyWithCode();
+        }
+
+        this.state = 345;
+        _la = this._input.LA(1);
+        if((((_la) & ~0x1f) == 0 && ((1 << _la) & ((1 << SHRDataElementParser.KW_MUST_BE) | (1 << SHRDataElementParser.KW_SHOULD_BE) | (1 << SHRDataElementParser.KW_COULD_BE))) !== 0)) {
+            this.state = 344;
+            this.bindingInfix();
+        }
+
+        this.state = 347;
+        this.match(SHRDataElementParser.KW_FROM);
+        this.state = 348;
+        this.valueset();
         this.state = 350;
-        this.codeFromVS();
+        _la = this._input.LA(1);
+        if(_la===SHRDataElementParser.KW_IF_COVERED) {
+            this.state = 349;
+            this.match(SHRDataElementParser.KW_IF_COVERED);
+        }
+
     } catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
 	        localctx.exception = re;

--- a/lib/parsers/SHRDataElementParserListener.js
+++ b/lib/parsers/SHRDataElementParserListener.js
@@ -308,15 +308,6 @@ SHRDataElementParserListener.prototype.exitCodeOrFQCode = function(ctx) {
 };
 
 
-// Enter a parse tree produced by SHRDataElementParser#codeFromVS.
-SHRDataElementParserListener.prototype.enterCodeFromVS = function(ctx) {
-};
-
-// Exit a parse tree produced by SHRDataElementParser#codeFromVS.
-SHRDataElementParserListener.prototype.exitCodeFromVS = function(ctx) {
-};
-
-
 // Enter a parse tree produced by SHRDataElementParser#bindingInfix.
 SHRDataElementParserListener.prototype.enterBindingInfix = function(ctx) {
 };
@@ -350,6 +341,15 @@ SHRDataElementParserListener.prototype.enterElementConstraint = function(ctx) {
 
 // Exit a parse tree produced by SHRDataElementParser#elementConstraint.
 SHRDataElementParserListener.prototype.exitElementConstraint = function(ctx) {
+};
+
+
+// Enter a parse tree produced by SHRDataElementParser#legacyWithCode.
+SHRDataElementParserListener.prototype.enterLegacyWithCode = function(ctx) {
+};
+
+// Exit a parse tree produced by SHRDataElementParser#legacyWithCode.
+SHRDataElementParserListener.prototype.exitLegacyWithCode = function(ctx) {
 };
 
 

--- a/lib/parsers/SHRDataElementParserVisitor.js
+++ b/lib/parsers/SHRDataElementParserVisitor.js
@@ -177,11 +177,6 @@ SHRDataElementParserVisitor.prototype.visitCodeOrFQCode = function(ctx) {
 };
 
 
-// Visit a parse tree produced by SHRDataElementParser#codeFromVS.
-SHRDataElementParserVisitor.prototype.visitCodeFromVS = function(ctx) {
-};
-
-
 // Visit a parse tree produced by SHRDataElementParser#bindingInfix.
 SHRDataElementParserVisitor.prototype.visitBindingInfix = function(ctx) {
 };
@@ -199,6 +194,11 @@ SHRDataElementParserVisitor.prototype.visitElementPath = function(ctx) {
 
 // Visit a parse tree produced by SHRDataElementParser#elementConstraint.
 SHRDataElementParserVisitor.prototype.visitElementConstraint = function(ctx) {
+};
+
+
+// Visit a parse tree produced by SHRDataElementParser#legacyWithCode.
+SHRDataElementParserVisitor.prototype.visitLegacyWithCode = function(ctx) {
 };
 
 

--- a/test/fixtures/dataElement/TypeConstraints.txt
+++ b/test/fixtures/dataElement/TypeConstraints.txt
@@ -50,12 +50,12 @@ Value:        code from http://standardhealthrecord.org/test/vs/Coded
 
 Element:      GroupBase
 0..1          Simple
-0..1          CodedFromValueSet with code from http://standardhealthrecord.org/test/vs/Coded2
+0..1          CodedFromValueSet from http://standardhealthrecord.org/test/vs/Coded2
 
 Element:      HasSimpleValue
 Value:        Simple
 
 Element:      Group2
 0..1          HasSimpleValue
-0..1          CodedFromValueSet with code from http://standardhealthrecord.org/test/vs/Coded2
+0..1          CodedFromValueSet from http://standardhealthrecord.org/test/vs/Coded2
 

--- a/test/fixtures/dataElement/VSConstraintOnField.txt
+++ b/test/fixtures/dataElement/VSConstraintOnField.txt
@@ -4,7 +4,7 @@ Namespace:  shr.test
 EntryElement: VSConstraintOnField
 Description:  "It is a group entry with a valueset constraint on a field"
 0..1    Simple
-0..1    CodedFromValueSet with code from http://standardhealthrecord.org/test/vs/Coded2
+0..1    CodedFromValueSet from http://standardhealthrecord.org/test/vs/Coded2
 
 Element:        Simple
 Value:          string

--- a/test/fixtures/dataElement/VSConstraintOnFieldChild.txt
+++ b/test/fixtures/dataElement/VSConstraintOnFieldChild.txt
@@ -5,7 +5,7 @@ EntryElement: VSConstraintOnFieldChild
 Description:  "It is a group entry with a valueset constraint on a field's child"
 0..1    Simple
 0..1    Complex
-1..2    Complex.CodedFromValueSet with code from http://standardhealthrecord.org/test/vs/Coded2
+1..2    Complex.CodedFromValueSet from http://standardhealthrecord.org/test/vs/Coded2
 
 Element:        Simple
 Value:          string

--- a/test/fixtures/dataElement/VSConstraintOnFieldWithBindingStrength.txt
+++ b/test/fixtures/dataElement/VSConstraintOnFieldWithBindingStrength.txt
@@ -2,16 +2,16 @@ Grammar:    DataElement 4.0
 Namespace:  shr.test
 
 EntryElement: RequiredVSConstraintOnField
-0..1    CodedThing with code must be from http://standardhealthrecord.org/test/vs/Coded2
+0..1    CodedThing must be from http://standardhealthrecord.org/test/vs/Coded2
 
 EntryElement: ExtensibleVSConstraintOnField
-0..1    CodedThing with code must be from http://standardhealthrecord.org/test/vs/Coded2 if covered
+0..1    CodedThing must be from http://standardhealthrecord.org/test/vs/Coded2 if covered
 
 EntryElement: PreferredVSConstraintOnField
-0..1    CodedThing with code should be from http://standardhealthrecord.org/test/vs/Coded2
+0..1    CodedThing should be from http://standardhealthrecord.org/test/vs/Coded2
 
 EntryElement: ExampleVSConstraintOnField
-0..1    CodedThing with code could be from http://standardhealthrecord.org/test/vs/Coded2
+0..1    CodedThing could be from http://standardhealthrecord.org/test/vs/Coded2
 
 Element:   CodedThing
 Value:     code

--- a/test/fixtures/dataElement/VSConstraintOnValue.txt
+++ b/test/fixtures/dataElement/VSConstraintOnValue.txt
@@ -3,7 +3,7 @@ Namespace:  shr.test
 
 EntryElement:   VSConstraintOnValue
 Description:    "It is an entry with a valueset constraint on the value"
-Value:          CodedFromValueSet with code from http://standardhealthrecord.org/test/vs/Coded2
+Value:          CodedFromValueSet from http://standardhealthrecord.org/test/vs/Coded2
 
 Element:   CodedFromValueSet
 Value:     code from http://standardhealthrecord.org/test/vs/Coded

--- a/test/fixtures/dataElement/VSConstraintOnValueChild.txt
+++ b/test/fixtures/dataElement/VSConstraintOnValueChild.txt
@@ -4,7 +4,7 @@ Namespace:  shr.test
 EntryElement:   VSConstraintOnValueChild
 Description:    "It is an entry with a valueset constraint on the value's child"
 Value:          Complex
-1..2            Complex.CodedFromValueSet with code from http://standardhealthrecord.org/test/vs/Coded2
+1..2            Complex.CodedFromValueSet from http://standardhealthrecord.org/test/vs/Coded2
 
 Element:        Complex
 0..1            Simple

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -176,12 +176,12 @@ describe('#importFromFilePath()', () => {
     expect(entry.value.constraints).to.have.length(1);
     const cst = entry.value.constraints[0];
     expect(cst).to.be.instanceof(ValueSetConstraint);
-    expect(cst.path).to.eql([pid('code')]);
+    expect(cst.path).to.be.empty;
     expect(cst.valueSet).to.equal('http://standardhealthrecord.org/test/vs/Coded2');
     expect(cst.bindingStrength).to.equal(REQUIRED);
   });
 
-  it('should correctly import an entry with a valueset constraint on the value\' child', () => {
+  it('should correctly import an entry with a valueset constraint on the value\'s child', () => {
     const specifications = importFixture('VSConstraintOnValueChild');
     const entry = expectAndGetEntry(specifications, 'shr.test', 'VSConstraintOnValueChild');
     expect(entry.description).to.equal('It is an entry with a valueset constraint on the value\'s child');
@@ -193,7 +193,7 @@ describe('#importFromFilePath()', () => {
     expect(entry.value.constraints[0].card.min).to.equal(1);
     expect(entry.value.constraints[0].card.max).to.equal(2);
     expect(entry.value.constraints[1]).to.be.instanceof(ValueSetConstraint);
-    expect(entry.value.constraints[1].path).to.eql([id('shr.test', 'CodedFromValueSet'), pid('code')]);
+    expect(entry.value.constraints[1].path).to.eql([id('shr.test', 'CodedFromValueSet')]);
     expect(entry.value.constraints[1].valueSet).to.equal('http://standardhealthrecord.org/test/vs/Coded2');
     expect(entry.value.constraints[1].bindingStrength).to.equal(REQUIRED);
     expect(entry.fields).to.be.empty;
@@ -212,7 +212,7 @@ describe('#importFromFilePath()', () => {
     const cmplx = group.fields[1];
     expect(cmplx.constraints).to.have.length(1);
     expect(cmplx.constraints[0]).to.be.instanceof(ValueSetConstraint);
-    expect(cmplx.constraints[0].path).to.eql([pid('code')]);
+    expect(cmplx.constraints[0].path).to.be.empty;
     expect(cmplx.constraints[0].valueSet).to.equal('http://standardhealthrecord.org/test/vs/Coded2');
     expect(cmplx.constraints[0].bindingStrength).to.equal(REQUIRED);
   });
@@ -233,7 +233,7 @@ describe('#importFromFilePath()', () => {
     expect(cmplx.constraints[0].card.min).to.equal(1);
     expect(cmplx.constraints[0].card.max).to.equal(2);
     expect(cmplx.constraints[1]).to.be.instanceof(ValueSetConstraint);
-    expect(cmplx.constraints[1].path).to.eql([id('shr.test', 'CodedFromValueSet'), pid('code')]);
+    expect(cmplx.constraints[1].path).to.eql([id('shr.test', 'CodedFromValueSet')]);
     expect(cmplx.constraints[1].valueSet).to.equal('http://standardhealthrecord.org/test/vs/Coded2');
     expect(cmplx.constraints[1].bindingStrength).to.equal(REQUIRED);
   });
@@ -275,7 +275,7 @@ describe('#importFromFilePath()', () => {
       const cmplx = entry.fields[0];
       expect(cmplx.constraints).to.have.length(1);
       expect(cmplx.constraints[0]).to.be.instanceof(ValueSetConstraint);
-      expect(cmplx.constraints[0].path).to.eql([pid('code')]);
+      expect(cmplx.constraints[0].path).to.be.empty;
       expect(cmplx.constraints[0].valueSet).to.equal('http://standardhealthrecord.org/test/vs/Coded2');
       expect(cmplx.constraints[0].bindingStrength).to.equal(answerKey[testCase]);
     }


### PR DESCRIPTION
 Authors can now simply declare constraints on elements with code-ish values without having to say "with code from", "with CodeableConcept from", etc.  In these cases, the expander module will move the constraint to its code value.