### PR TITLE
Fix VS Binding Strength Bug (#37)

### DIFF
--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -335,7 +335,7 @@ class DataElementImporter extends SHRDataElementParserListener {
       // This error should never occur unless the ANTLR grammar changes
       logger.error('Unsupported binding strength: %s.  Defaulting to REQUIRED.', bindingCtx.getText());
     }
-    return REQUIRED;
+    return vsConstraint.KW_IF_COVERED() ? EXTENSIBLE : REQUIRED;
   }
 
   processCodeOrFQCode(ctx) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-text-import",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "description": "Imports Standard Health Record (SHR) elements from their custom grammar to the SHR models",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The importer dropped "if covered" declarations unless they were used with "must be from" as well.  Now you can use them with just plain "from".