### PR TITLE
Fixed issue shr-cli#23: Crash when element name doesn't have leading Capitalization

### DIFF
--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -100,6 +100,8 @@ class DataElementImporter extends SHRDataElementParserListener {
     logger = logger.child({ shrId: id.fqn });
     logger.parent = lastLogger;
     logger.debug('Start importing data element');
+
+    if (ctx.elementHeader().simpleName().LOWER_WORD()) { logger.error("Element name '%s' should begin with a capital letter", ctx.elementHeader().simpleName().getText()); }
   }
 
   exitElementDef(ctx) {
@@ -114,6 +116,8 @@ class DataElementImporter extends SHRDataElementParserListener {
   enterEntryDef(ctx) {
     const id = new Identifier(this._currentNs, ctx.entryHeader().simpleName().getText());
     this._currentDef = new DataElement(id, true).withGrammarVersion(this._currentGrammarVersion);
+    
+    if (ctx.entryHeader().simpleName().LOWER_WORD()) { logger.error("Element name '%s' should begin with a capital letter", ctx.elementHeader().simpleName().getText()); }
   }
 
   exitEntryDef(ctx) {

--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -117,7 +117,7 @@ class DataElementImporter extends SHRDataElementParserListener {
     const id = new Identifier(this._currentNs, ctx.entryHeader().simpleName().getText());
     this._currentDef = new DataElement(id, true).withGrammarVersion(this._currentGrammarVersion);
     
-    if (ctx.entryHeader().simpleName().LOWER_WORD()) { logger.error("Element name '%s' should begin with a capital letter", ctx.elementHeader().simpleName().getText()); }
+    if (ctx.entryHeader().simpleName().LOWER_WORD()) { logger.error("Element name '%s' should begin with a capital letter", ctx.entryHeader().simpleName().getText()); }
   }
 
   exitEntryDef(ctx) {

--- a/lib/parsers/SHRDataElementParser.js
+++ b/lib/parsers/SHRDataElementParser.js
@@ -40,7 +40,7 @@ var serializedATN = ["\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd",
     "\n\60\3\61\3\61\3\62\3\62\3\62\3\62\3\63\3\63\5\63\u019c\n\63\3\64\3",
     "\64\5\64\u01a0\n\64\3\64\2\2\65\2\4\6\b\n\f\16\20\22\24\26\30\32\34",
     "\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`bdf\2\n\4\2((*+\3\2AB",
-    "\3\2?@\3\2\23\25\3\2\35\36\3\2\32\33\3\2-=\4\2$$>>\u01b2\2h\3\2\2\2",
+    "\3\2?A\3\2\23\25\3\2\35\36\3\2\32\33\3\2-=\4\2$$>>\u01b2\2h\3\2\2\2",
     "\4w\3\2\2\2\6}\3\2\2\2\b\u0087\3\2\2\2\n\u008b\3\2\2\2\f\u0091\3\2\2",
     "\2\16\u0095\3\2\2\2\20\u009d\3\2\2\2\22\u00a2\3\2\2\2\24\u00a4\3\2\2",
     "\2\26\u00ab\3\2\2\2\30\u00b0\3\2\2\2\32\u00b6\3\2\2\2\34\u00ba\3\2\2",
@@ -1767,7 +1767,7 @@ SHRDataElementParser.prototype.values = function() {
         this.state = 199;
         this._errHandler.sync(this);
         _la = this._input.LA(1);
-        while(_la===SHRDataElementParser.KW_REF || _la===SHRDataElementParser.KW_TBD || ((((_la - 35)) & ~0x1f) == 0 && ((1 << (_la - 35)) & ((1 << (SHRDataElementParser.OPEN_PAREN - 35)) | (1 << (SHRDataElementParser.KW_BOOLEAN - 35)) | (1 << (SHRDataElementParser.KW_INTEGER - 35)) | (1 << (SHRDataElementParser.KW_STRING - 35)) | (1 << (SHRDataElementParser.KW_DECIMAL - 35)) | (1 << (SHRDataElementParser.KW_URI - 35)) | (1 << (SHRDataElementParser.KW_BASE64_BINARY - 35)) | (1 << (SHRDataElementParser.KW_INSTANT - 35)) | (1 << (SHRDataElementParser.KW_DATE - 35)) | (1 << (SHRDataElementParser.KW_DATE_TIME - 35)) | (1 << (SHRDataElementParser.KW_TIME - 35)) | (1 << (SHRDataElementParser.KW_CODE - 35)) | (1 << (SHRDataElementParser.KW_OID - 35)) | (1 << (SHRDataElementParser.KW_ID - 35)) | (1 << (SHRDataElementParser.KW_MARKDOWN - 35)) | (1 << (SHRDataElementParser.KW_UNSIGNED_INT - 35)) | (1 << (SHRDataElementParser.KW_POSITIVE_INT - 35)) | (1 << (SHRDataElementParser.KW_XHTML - 35)) | (1 << (SHRDataElementParser.WHOLE_NUMBER - 35)) | (1 << (SHRDataElementParser.ALL_CAPS - 35)) | (1 << (SHRDataElementParser.UPPER_WORD - 35)) | (1 << (SHRDataElementParser.DOT_SEPARATED_UW - 35)))) !== 0)) {
+        while(_la===SHRDataElementParser.KW_REF || _la===SHRDataElementParser.KW_TBD || ((((_la - 35)) & ~0x1f) == 0 && ((1 << (_la - 35)) & ((1 << (SHRDataElementParser.OPEN_PAREN - 35)) | (1 << (SHRDataElementParser.KW_BOOLEAN - 35)) | (1 << (SHRDataElementParser.KW_INTEGER - 35)) | (1 << (SHRDataElementParser.KW_STRING - 35)) | (1 << (SHRDataElementParser.KW_DECIMAL - 35)) | (1 << (SHRDataElementParser.KW_URI - 35)) | (1 << (SHRDataElementParser.KW_BASE64_BINARY - 35)) | (1 << (SHRDataElementParser.KW_INSTANT - 35)) | (1 << (SHRDataElementParser.KW_DATE - 35)) | (1 << (SHRDataElementParser.KW_DATE_TIME - 35)) | (1 << (SHRDataElementParser.KW_TIME - 35)) | (1 << (SHRDataElementParser.KW_CODE - 35)) | (1 << (SHRDataElementParser.KW_OID - 35)) | (1 << (SHRDataElementParser.KW_ID - 35)) | (1 << (SHRDataElementParser.KW_MARKDOWN - 35)) | (1 << (SHRDataElementParser.KW_UNSIGNED_INT - 35)) | (1 << (SHRDataElementParser.KW_POSITIVE_INT - 35)) | (1 << (SHRDataElementParser.KW_XHTML - 35)) | (1 << (SHRDataElementParser.WHOLE_NUMBER - 35)) | (1 << (SHRDataElementParser.ALL_CAPS - 35)) | (1 << (SHRDataElementParser.UPPER_WORD - 35)) | (1 << (SHRDataElementParser.LOWER_WORD - 35)) | (1 << (SHRDataElementParser.DOT_SEPARATED_UW - 35)))) !== 0)) {
             this.state = 196;
             this.field();
             this.state = 201;
@@ -2341,6 +2341,7 @@ SHRDataElementParser.prototype.basedOnProp = function() {
         switch(this._input.LA(1)) {
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
+        case SHRDataElementParser.LOWER_WORD:
         case SHRDataElementParser.DOT_SEPARATED_UW:
             this.state = 251;
             this.simpleOrFQName();
@@ -2812,6 +2813,10 @@ SimpleNameContext.prototype.ALL_CAPS = function() {
     return this.getToken(SHRDataElementParser.ALL_CAPS, 0);
 };
 
+SimpleNameContext.prototype.LOWER_WORD = function() {
+    return this.getToken(SHRDataElementParser.LOWER_WORD, 0);
+};
+
 SimpleNameContext.prototype.enterRule = function(listener) {
     if(listener instanceof SHRDataElementParserListener ) {
         listener.enterSimpleName(this);
@@ -2846,7 +2851,7 @@ SHRDataElementParser.prototype.simpleName = function() {
         this.enterOuterAlt(localctx, 1);
         this.state = 277;
         _la = this._input.LA(1);
-        if(!(_la===SHRDataElementParser.ALL_CAPS || _la===SHRDataElementParser.UPPER_WORD)) {
+        if(!(((((_la - 61)) & ~0x1f) == 0 && ((1 << (_la - 61)) & ((1 << (SHRDataElementParser.ALL_CAPS - 61)) | (1 << (SHRDataElementParser.UPPER_WORD - 61)) | (1 << (SHRDataElementParser.LOWER_WORD - 61)))) !== 0))) {
         this._errHandler.recoverInline(this);
         }
         else {
@@ -2991,6 +2996,7 @@ SHRDataElementParser.prototype.simpleOrFQName = function() {
         switch(this._input.LA(1)) {
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
+        case SHRDataElementParser.LOWER_WORD:
             this.enterOuterAlt(localctx, 1);
             this.state = 281;
             this.simpleName();
@@ -3505,6 +3511,7 @@ SHRDataElementParser.prototype.typeConstraint = function() {
         switch(this._input.LA(1)) {
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
+        case SHRDataElementParser.LOWER_WORD:
         case SHRDataElementParser.DOT_SEPARATED_UW:
             this.state = 306;
             this.simpleOrFQName();
@@ -3992,6 +3999,7 @@ SHRDataElementParser.prototype.legacyWithCode = function() {
             break;
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
+        case SHRDataElementParser.LOWER_WORD:
         case SHRDataElementParser.DOT_SEPARATED_UW:
             this.state = 352;
             this.simpleOrFQName();
@@ -4454,6 +4462,7 @@ SHRDataElementParser.prototype.elementTypeConstraint = function() {
         switch(this._input.LA(1)) {
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
+        case SHRDataElementParser.LOWER_WORD:
         case SHRDataElementParser.DOT_SEPARATED_UW:
             this.state = 379;
             this.simpleOrFQName();
@@ -4744,6 +4753,7 @@ SHRDataElementParser.prototype.valueset = function() {
             break;
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
+        case SHRDataElementParser.LOWER_WORD:
             this.enterOuterAlt(localctx, 4);
             this.state = 397;
             this.simpleName();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-text-import",
-  "version": "5.0.0-beta.6",
+  "version": "5.0.0-beta.7",
   "description": "Imports Standard Health Record (SHR) elements from their custom grammar to the SHR models",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adds 'support' for LOWER_WORD in grammar, but includes a check in the Listener to catch lowercase names and throw an error.

Solution to error: https://github.com/standardhealth/shr-cli/issues/23