### PR TITLE
Map to profiles

### DIFF
--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -101,7 +101,7 @@ class DataElementImporter extends SHRDataElementParserListener {
     logger.parent = lastLogger;
     logger.debug('Start importing data element');
 
-    if (ctx.elementHeader().simpleName().LOWER_WORD()) { logger.error('Element name "%s" should begin with a capital letter', ctx.elementHeader().simpleName().getText()); }
+    if (ctx.elementHeader().simpleName().LOWER_WORD()) { logger.error('Element name "%s" should begin with a capital letter. ERROR_CODE:11001', ctx.elementHeader().simpleName().getText()); }
   }
 
   exitElementDef(ctx) {
@@ -116,8 +116,8 @@ class DataElementImporter extends SHRDataElementParserListener {
   enterEntryDef(ctx) {
     const id = new Identifier(this._currentNs, ctx.entryHeader().simpleName().getText());
     this._currentDef = new DataElement(id, true).withGrammarVersion(this._currentGrammarVersion);
-
-    if (ctx.entryHeader().simpleName().LOWER_WORD()) { logger.error('Element name "%s" should begin with a capital letter', ctx.entryHeader().simpleName().getText()); }
+    
+    if (ctx.entryHeader().simpleName().LOWER_WORD()) { logger.error('Entry Element name "%s" should begin with a capital letter. ERROR_CODE:11002', ctx.entryHeader().simpleName().getText()); }
   }
 
   exitEntryDef(ctx) {
@@ -127,7 +127,7 @@ class DataElementImporter extends SHRDataElementParserListener {
   enterBasedOnProp(ctx) {
     const identifier = this.resolveToIdentifierOrTBD(ctx);
     if (identifier.isValueKeyWord) {
-      logger.error('Elements cannot be based on "Value" keyword');
+      logger.error('Elements cannot be based on "Value" keyword. ERROR_CODE:11023');
     } else {
       this._currentDef.addBasedOn(identifier);
     }
@@ -159,7 +159,7 @@ class DataElementImporter extends SHRDataElementParserListener {
     const field = this.processCountAndTypes(ctx.count(), ctx.fieldType());
     if (field instanceof IncompleteValue && field.identifier && field.identifier.isValueKeyWord) {
       if (this._currentDef.value) {
-        logger.error('Elements cannot use "Value:" modifier and specify "Value" field at same time.');
+        logger.error('Elements cannot use "Value:" modifier and specify "Value" field at same time. ERROR_CODE:11024');
         return;
       }
       this._currentDef.value = field;
@@ -247,7 +247,7 @@ class DataElementImporter extends SHRDataElementParserListener {
       } else if (ctx.ref()) {
         const refIdentifier = this.resolveToIdentifier(ctx.ref().simpleOrFQName().getText());
         if (refIdentifier.isValueKeyWord) {
-          logger.error('ref(Value) is an unsupported construct; treating as Value without the reference.');
+          logger.error('ref(Value) is an unsupported construct; treating as Value without the reference. ERROR_CODE:11026');
           value = new IdentifiableValue(refIdentifier);
         } else {
           value = new RefValue(refIdentifier);
@@ -280,7 +280,7 @@ class DataElementImporter extends SHRDataElementParserListener {
         if (cst.elementTypeConstraint()) {
           const newIdentifier = this.resolveToIdentifierOrTBD(cst.elementTypeConstraint());
           if (newIdentifier.isValueKeyWord) {
-            logger.error('Fields cannot be constrained to type "Value"');
+            logger.error('Fields cannot be constrained to type "Value". ERROR_CODE:11025');
           } else {
             const onValue = cst.elementTypeConstraint().KW_VALUE_IS_TYPE() ? true : false;
             value.addConstraint(new TypeConstraint(newIdentifier, path, onValue));
@@ -289,7 +289,7 @@ class DataElementImporter extends SHRDataElementParserListener {
           for (const typeConstraint of cst.elementIncludesTypeConstraint().typeConstraint()) {
             const newIdentifier = this.resolveToIdentifierOrTBD(typeConstraint);
             if (newIdentifier.isValueKeyWord) {
-              logger.error('Fields cannot be constrained to type "Value"');
+              logger.error('Fields cannot be constrained to type "Value". ERROR_CODE:11025');
             } else {
               [min, max] = this.getMinMax(typeConstraint.count());
               const isOnValue = (path.length > 0 && path[0].name == "Value");
@@ -332,7 +332,7 @@ class DataElementImporter extends SHRDataElementParserListener {
     } else if (ctx.ref()) {
       const refIdentifier = this.resolveToIdentifier(ctx.ref().simpleOrFQName().getText());
       if (refIdentifier.isValueKeyWord) {
-        logger.error('ref(Value) is an unsupported construct; treating as Value without the reference.');
+        logger.error('ref(Value) is an unsupported construct; treating as Value without the reference. ERROR_CODE:11026');
         value = new IdentifiableValue(refIdentifier);
       } else {
         value = new RefValue(refIdentifier);
@@ -377,7 +377,7 @@ class DataElementImporter extends SHRDataElementParserListener {
         }
       }
       if (!found) {
-        logger.error('Unable to resolve value set reference: %s', name);
+        logger.error('Unable to resolve value set reference: %s. ERROR_CODE:11003', name);
         vs = `urn:tbd:${name}`;
       }
     } else if (vsConstraint.valueset().tbd()) {
@@ -401,7 +401,7 @@ class DataElementImporter extends SHRDataElementParserListener {
         return EXAMPLE;
       }
       // This error should never occur unless the ANTLR grammar changes
-      logger.error('Unsupported binding strength: %s.  Defaulting to REQUIRED.', bindingCtx.getText());
+      logger.error('Unsupported binding strength: %s.  Defaulting to REQUIRED. ERROR_CODE:11004', bindingCtx.getText());
     }
     return vsConstraint.KW_IF_COVERED() ? EXTENSIBLE : REQUIRED;
   }

--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -185,6 +185,15 @@ class DataElementImporter extends SHRDataElementParserListener {
           return;
         }
       }
+      // If we got here, we didn't find anything -- but if it's an Entry field, resolve it to a 1..1 IdentifiableValue
+      if (field.identifier.equals(new Identifier('shr.base', 'Entry'))) {
+        const entryField = new IdentifiableValue(field.identifier).withMinMax(1, 1);
+        for (const cst of field.constraints) {
+          entryField.addConstraint(cst);
+        }
+        this._currentDef.addField(entryField);
+        return;
+      }
     }
 
     // Search through the fields to see if there are any IncompleteValues we can now resolve
@@ -470,8 +479,10 @@ class DataElementImporter extends SHRDataElementParserListener {
       return new Identifier(ns, name);
     }
 
-    // No specified namespace -- is either special 'Value' case, primitive, or something we need to resolve
-    if (ref === 'Value') {
+    // No specified namespace -- is either special 'Entry' or 'Value' case, primitive, or something we need to resolve
+    if (ref === 'Entry') {
+      return new Identifier('shr.base', ref);
+    } else if (ref === 'Value') {
       return new Identifier('', ref);
     } else if (PRIMITIVES.includes(ref)) {
       return new PrimitiveIdentifier(ref);

--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -101,7 +101,7 @@ class DataElementImporter extends SHRDataElementParserListener {
     logger.parent = lastLogger;
     logger.debug('Start importing data element');
 
-    if (ctx.elementHeader().simpleName().LOWER_WORD()) { logger.error("Element name '%s' should begin with a capital letter", ctx.elementHeader().simpleName().getText()); }
+    if (ctx.elementHeader().simpleName().LOWER_WORD()) { logger.error('Element name "%s" should begin with a capital letter', ctx.elementHeader().simpleName().getText()); }
   }
 
   exitElementDef(ctx) {
@@ -116,8 +116,8 @@ class DataElementImporter extends SHRDataElementParserListener {
   enterEntryDef(ctx) {
     const id = new Identifier(this._currentNs, ctx.entryHeader().simpleName().getText());
     this._currentDef = new DataElement(id, true).withGrammarVersion(this._currentGrammarVersion);
-    
-    if (ctx.entryHeader().simpleName().LOWER_WORD()) { logger.error("Element name '%s' should begin with a capital letter", ctx.entryHeader().simpleName().getText()); }
+
+    if (ctx.entryHeader().simpleName().LOWER_WORD()) { logger.error('Element name "%s" should begin with a capital letter', ctx.entryHeader().simpleName().getText()); }
   }
 
   exitEntryDef(ctx) {
@@ -125,7 +125,12 @@ class DataElementImporter extends SHRDataElementParserListener {
   }
 
   enterBasedOnProp(ctx) {
-    this._currentDef.addBasedOn(this.resolveToIdentifierOrTBD(ctx));
+    const identifier = this.resolveToIdentifierOrTBD(ctx);
+    if (identifier.isValueKeyWord) {
+      logger.error('Elements cannot be based on "Value" keyword');
+    } else {
+      this._currentDef.addBasedOn(identifier);
+    }
   }
 
   enterDescriptionProp(ctx) {
@@ -152,7 +157,15 @@ class DataElementImporter extends SHRDataElementParserListener {
 
   enterField(ctx) {
     const field = this.processCountAndTypes(ctx.count(), ctx.fieldType());
-    this.addFieldToCurrentDef(field);
+    if (field instanceof IncompleteValue && field.identifier && field.identifier.isValueKeyWord) {
+      if (this._currentDef.value) {
+        logger.error('Elements cannot use "Value:" modifier and specify "Value" field at same time.');
+        return;
+      }
+      this._currentDef.value = field;
+    } else {
+      this.addFieldToCurrentDef(field);
+    }
   }
 
   // addFieldToCurrentDef contains special logic to handle IncompleteValues.  If an IncompleteValue matches an already
@@ -213,7 +226,23 @@ class DataElementImporter extends SHRDataElementParserListener {
       let value;
       let path = [];
       if (ewc.simpleOrFQName()) {
-        value = new IdentifiableValue(this.resolveToIdentifier(ewc.simpleOrFQName().getText()));
+        const identifier = this.resolveToIdentifier(ewc.simpleOrFQName().getText());
+        if (identifier.isValueKeyWord) {
+          value = new IncompleteValue(identifier);
+        } else {
+          value = new IdentifiableValue(identifier);
+        }
+        if (typeof min !== 'undefined') {
+          value.setMinMax(min, max);
+        }
+      } else if (ctx.ref()) {
+        const refIdentifier = this.resolveToIdentifier(ctx.ref().simpleOrFQName().getText());
+        if (refIdentifier.isValueKeyWord) {
+          logger.error('ref(Value) is an unsupported construct; treating as Value without the reference.');
+          value = new IdentifiableValue(refIdentifier);
+        } else {
+          value = new RefValue(refIdentifier);
+        }
         if (typeof min !== 'undefined') {
           value.setMinMax(min, max);
         }
@@ -241,14 +270,22 @@ class DataElementImporter extends SHRDataElementParserListener {
         const cst = ewc.elementConstraint();
         if (cst.elementTypeConstraint()) {
           const newIdentifier = this.resolveToIdentifierOrTBD(cst.elementTypeConstraint());
-          const onValue = cst.elementTypeConstraint().KW_VALUE_IS_TYPE() ? true : false;
-          value.addConstraint(new TypeConstraint(newIdentifier, path, onValue));
+          if (newIdentifier.isValueKeyWord) {
+            logger.error('Fields cannot be constrained to type "Value"');
+          } else {
+            const onValue = cst.elementTypeConstraint().KW_VALUE_IS_TYPE() ? true : false;
+            value.addConstraint(new TypeConstraint(newIdentifier, path, onValue));
+          }
         } else if (cst.elementIncludesTypeConstraint()) {
           for (const typeConstraint of cst.elementIncludesTypeConstraint().typeConstraint()) {
             const newIdentifier = this.resolveToIdentifierOrTBD(typeConstraint);
-            [min, max] = this.getMinMax(typeConstraint.count());
-            const isOnValue = (path.length > 0 && path[0].name == "Value");
-            value.addConstraint(new IncludesTypeConstraint(newIdentifier, new Cardinality(min, max), path, isOnValue));
+            if (newIdentifier.isValueKeyWord) {
+              logger.error('Fields cannot be constrained to type "Value"');
+            } else {
+              [min, max] = this.getMinMax(typeConstraint.count());
+              const isOnValue = (path.length > 0 && path[0].name == "Value");
+              value.addConstraint(new IncludesTypeConstraint(newIdentifier, new Cardinality(min, max), path, isOnValue));
+            }
           }
         } else if (cst.elementCodeVSConstraint()) {
           const vsConstraint = cst.elementCodeVSConstraint();
@@ -277,9 +314,20 @@ class DataElementImporter extends SHRDataElementParserListener {
 
     let value;
     if (ctx.simpleOrFQName()) {
-      value = new IdentifiableValue(this.resolveToIdentifier(ctx.simpleOrFQName().getText()));
+      const identifier = this.resolveToIdentifier(ctx.simpleOrFQName().getText());
+      if (identifier.isValueKeyWord) {
+        value = new IncompleteValue(identifier);
+      } else {
+        value = new IdentifiableValue(identifier);
+      }
     } else if (ctx.ref()) {
-      value = new RefValue(this.resolveToIdentifier(ctx.ref().simpleOrFQName().getText()));
+      const refIdentifier = this.resolveToIdentifier(ctx.ref().simpleOrFQName().getText());
+      if (refIdentifier.isValueKeyWord) {
+        logger.error('ref(Value) is an unsupported construct; treating as Value without the reference.');
+        value = new IdentifiableValue(refIdentifier);
+      } else {
+        value = new RefValue(refIdentifier);
+      }
     } else if (ctx.tbd()) {
       if (ctx.tbd().STRING()) {
         value = new TBD(stripDelimitersFromToken(ctx.tbd().STRING()));
@@ -422,8 +470,10 @@ class DataElementImporter extends SHRDataElementParserListener {
       return new Identifier(ns, name);
     }
 
-    // No specified namespace -- is either primitive or something we need to resolve
-    if (PRIMITIVES.includes(ref)) {
+    // No specified namespace -- is either special 'Value' case, primitive, or something we need to resolve
+    if (ref === 'Value') {
+      return new Identifier('', ref);
+    } else if (PRIMITIVES.includes(ref)) {
       return new PrimitiveIdentifier(ref);
     }
     var ns;

--- a/lib/errorListener.js
+++ b/lib/errorListener.js
@@ -6,8 +6,25 @@ class SHRErrorListener extends ErrorListener {
     this._logger = bunyanLogger;
   }
 
+  codeMessage(msg) {
+    var code;
+
+    if (msg.match(/^extraneous input .+ expecting/)) {
+      code = 11023;
+    } else if (msg.match(/^mismatched input .+ expecting/)) {
+      code = 11016;
+    } else if (msg.match(/^token recognition error at: '.+'/)) {
+      code = 11015;
+    } else {
+      return msg;
+    }
+    
+    msg = `${msg}. ERROR_CODE:${code}`
+    return msg;
+  }
+
   syntaxError(recognizer, offendingSymbol, line, column, msg, e) {
-    this._logger.error({line, column}, msg);
+    this._logger.error({line, column}, this.codeMessage(msg));
   }
 }
 

--- a/lib/mappingListener.js
+++ b/lib/mappingListener.js
@@ -147,7 +147,7 @@ class MappingImporter extends SHRMapParserListener {
             sourcePath.push(new TBD());
           }
         } else {
-          logger.error('Error parsing source path: %s', c.source().getText());
+          logger.error('Error parsing source path: %s. ERROR_CODE:11005', c.source().getText());
         }
       }
     }

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -33,11 +33,11 @@ class Preprocessor extends SHRDataElementParserVisitor {
     if (file != null) {
       try { configFile = JSON.parse(new FileStream(file)); } 
       catch (e) {
-        logger.error("Invalid config file. Should be valid JSON dictionary");
+        logger.error("Invalid config file. Should be valid JSON dictionary. ERROR_CODE:11006");
         return defaults;
       }
     } else {
-      logger.warn(`No project configuration file found, currently using default EXAMPLE identifiers. Auto-generating a proper 'config.json' in your specifications folder.`);
+      logger.warn(`No project configuration file found, currently using default EXAMPLE identifiers. Auto-generating a proper 'config.json' in your specifications folder. ERROR_CODE:01001`);
       return defaults;
     }
 
@@ -50,7 +50,7 @@ class Preprocessor extends SHRDataElementParserVisitor {
         } 
         
         configFile[key] = defaults[key];
-        logger.warn("Config file missing key: %s, using default key: %s instead", key, defaults[key]);
+        logger.warn("Configuration file missing key: %s, using default key: %s instead. ERROR_CODE:01002", key, defaults[key]);
       } else {
         //Additional compatibility logic
         if ( (key === "projectURL" || key === "fhirURL" ) && configFile[key].endsWith('/')) {
@@ -139,7 +139,7 @@ class Preprocessor extends SHRDataElementParserVisitor {
     const major = parseInt(version.WHOLE_NUMBER()[0], 10);
     const minor = parseInt(version.WHOLE_NUMBER()[2], 10);
     if (GRAMMAR_VERSION.major != major || GRAMMAR_VERSION.minor < minor) {
-      logger.error('Unsupported grammar version: %s.%s', major, minor);
+      logger.error('Unsupported grammar version: %s.%s. ERROR_CODE:11007', major, minor);
       return false;
     }
     return true;
@@ -183,7 +183,7 @@ class PreprocessedData {
   resolvePath(name, ...namespace) {
     // First ensure namespaces were passed in
     if (namespace.length == 0) {
-      return { error: `Cannot resolve path without namespaces` };
+      return { error: `Cannot resolve path without namespaces. ERROR_CODE:11017` };
     }
 
     // Special handling for default paths
@@ -212,9 +212,9 @@ class PreprocessedData {
       }
     }
     if (!result.hasOwnProperty('url')) {
-      result['error'] = `Failed to resolve path for ${name}.`;
+      result['error'] = `Failed to resolve path for ${name}. ERROR_CODE:11018`;
     } else if (conflict) {
-      result['error'] = `Found conflicting path for ${name} in multiple namespaces: ${foundNamespaces}`;
+      result['error'] = `Found conflicting path for ${name} in multiple namespaces: ${foundNamespaces}. ERROR_CODE:11019`;
     }
     return result;
   }
@@ -234,9 +234,9 @@ class PreprocessedData {
       }
     }
     if (!result.hasOwnProperty('url')) {
-      result['error'] = `Failed to resolve vocabulary for ${name}.`;
+      result['error'] = `Failed to resolve vocabulary for ${name}. ERROR_CODE:11020`;
     } else if (conflict) {
-      result['error'] = `Found conflicting vocabularies for ${name} in multiple namespaces: ${foundNamespaces}`;
+      result['error'] = `Found conflicting vocabularies for ${name} in multiple namespaces: ${foundNamespaces}. ERROR_CODE:11021`;
     }
     return result;
   }
@@ -253,9 +253,9 @@ class PreprocessedData {
       }
     }
     if (!result.hasOwnProperty('namespace')) {
-      result['error'] = `Failed to resolve definition for ${name}.`;
+      result['error'] = `Failed to resolve definition for ${name}. ERROR_CODE:11013`;
     } else if (foundNamespaces.length > 1) {
-      result['error'] = `Found conflicting definitions for ${name} in multiple namespaces: ${foundNamespaces}`;
+      result['error'] = `Found conflicting definitions for ${name} in multiple namespaces: ${foundNamespaces}. ERROR_CODE:11022`;
     }
     return result;
   }

--- a/lib/valueSetListener.js
+++ b/lib/valueSetListener.js
@@ -98,12 +98,12 @@ class ValueSetImporter extends SHRValueSetParserListener {
   enterValuesetDef(ctx) {
     const h = ctx.valuesetHeader();
     if (h.URL()) {
-      logger.error('Defining value sets by URL has been deprecated in ValueSet files.  ValueSet %s ignored.', h.URL().getText());
+      logger.error('Defining value sets by URL has been deprecated in ValueSet files.  ValueSet %s ignored. ERROR_CODE:11008', h.URL().getText());
       // Set a dummy unsupported def so the rest of the parsing can occur -- but it won't be added to the definitions
       this._currentDef = new ValueSet(new Identifier('unsupported', 'Unsupported'), 'urn:unsupported');
       return;
     } else if (h.URN_OID()) {
-      logger.error('Defining value sets by URN has been deprecated in ValueSet files.  ValueSet %s ignored.', h.URN_OID().getText());
+      logger.error('Defining value sets by URN has been deprecated in ValueSet files.  ValueSet %s ignored. ERROR_CODE:11009', h.URN_OID().getText());
       // Set a dummy unsupported def so the rest of the parsing can occur -- but it won't be added to the definitions
       this._currentDef = new ValueSet(new Identifier('unsupported', 'Unsupported'), 'urn:unsupported');
       return;
@@ -175,7 +175,7 @@ class ValueSetImporter extends SHRValueSetParserListener {
     const alias = ctx.ALL_CAPS().getText();
     const system = this._csMap.get(alias);
     if (typeof system === 'undefined') {
-      logger.error('Couldn\'t resolve code system for alias: %s', alias);
+      logger.error('Couldn\'t resolve code system for alias: %s. ERROR_CODE:11010', alias);
       return;
     }
     this._currentDef.addValueSetIncludesFromCodeSystemRule(system);
@@ -193,11 +193,11 @@ class ValueSetImporter extends SHRValueSetParserListener {
   }
 
   enterUsesStatement(ctx) {
-    logger.error('Uses statements have been deprecated in ValueSet files.  Uses statement ignored.');
+    logger.error('Uses statements have been deprecated in ValueSet files.  Uses statement ignored. ERROR_CODE:11011');
   }
 
   enterPathDef(ctx) {
-    logger.error('Only default path definitions are allowed in ValueSet files.  Path definition ignored.');
+    logger.error('Only default path definitions are allowed in ValueSet files.  Path definition ignored. ERROR_CODE:11012');
   }
 
   processFullyQualifiedCode(ctx) {
@@ -205,7 +205,7 @@ class ValueSetImporter extends SHRValueSetParserListener {
       const alias = ctx.ALL_CAPS().getText();
       const system = this._csMap.get(alias);
       if (typeof system === 'undefined') {
-        logger.error('Couldn\'t resolve code system for alias: %s', alias);
+        logger.error('Couldn\'t resolve code system for alias: %s. ERROR_CODE:11010', alias);
         return;
       }
       const code = ctx.code().CODE().getText().substr(1); // substr to skip the '#'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-text-import",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Imports Standard Health Record (SHR) elements from their custom grammar to the SHR models",
   "author": "",
   "license": "Apache-2.0",
@@ -19,12 +19,12 @@
   "dependencies": {
     "antlr4": "~4.6.0",
     "bunyan": "^1.8.9",
-    "shr-models": "^5.0.0"
+    "shr-models": "^5.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-test-helpers": "^5.0.0"
+    "shr-test-helpers": "^5.0.1"
   }
 }

--- a/test/fixtures/dataElement/CodeConstraintOnValueKeyWord.txt
+++ b/test/fixtures/dataElement/CodeConstraintOnValueKeyWord.txt
@@ -1,0 +1,15 @@
+Grammar:     DataElement 5.0
+Namespace:   shr.test
+Uses:      shr.core
+
+CodeSystem:     FOO = http://foo.org
+
+EntryElement:   BaseElement
+Value:          CodedElement
+
+EntryElement:   ChildElement
+Based on:       BaseElement
+Value is FOO#bar "FooBar"
+
+Element:   CodedElement
+Value:     Coding from http://standardhealthrecord.org/test/vs/Coded

--- a/test/fixtures/dataElement/VSConstraintOnValueKeyWord.txt
+++ b/test/fixtures/dataElement/VSConstraintOnValueKeyWord.txt
@@ -1,0 +1,12 @@
+Grammar:     DataElement 5.0
+Namespace:   shr.test
+
+EntryElement:   BaseElement
+Value:          CodedElement
+
+EntryElement:   ChildElement
+Based on:       BaseElement
+Value from http://standardhealthrecord.org/test/vs/Coded
+
+Element:   CodedElement
+Value:     code

--- a/test/fixtures/dataElement/ZeroedOutValue.txt
+++ b/test/fixtures/dataElement/ZeroedOutValue.txt
@@ -1,0 +1,10 @@
+Grammar:     DataElement 5.0
+Namespace:   shr.test
+Description: "The SHR test namespace"
+
+EntryElement:   OptionalValue
+Value:          0..1 string
+
+EntryElement:   ZeroedOutValue
+Based on:        OptionalValue
+0..0 Value

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -1,6 +1,6 @@
 const {expect} = require('chai');
 const {importFromFilePath, importConfigFromFilePath, setLogger} = require('../index');
-const {Version, DataElement, Value, RefValue, ChoiceValue, Identifier, PrimitiveIdentifier, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, CardConstraint, TBD, REQUIRED, EXTENSIBLE, PREFERRED, EXAMPLE} = require('shr-models');
+const {Version, DataElement, Value, RefValue, ChoiceValue, IncompleteValue, Identifier, PrimitiveIdentifier, Cardinality, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, CardConstraint, TBD, REQUIRED, EXTENSIBLE, PREFERRED, EXAMPLE} = require('shr-models');
 const err = require('shr-test-helpers/errors');
 
 // Set the logger -- this is needed for detecting and checking errors
@@ -259,7 +259,7 @@ describe('#importFromFilePath()', () => {
       'ExtensibleVSConstraintOnValue': EXTENSIBLE,
       'PreferredVSConstraintOnValue': PREFERRED,
       'ExampleVSConstraintOnValue': EXAMPLE
-    }
+    };
     for (const testCase of Object.keys(answerKey)) {
       const entry = expectAndGetEntry(specifications, 'shr.test', testCase);
       expectCardOne(entry.value);
@@ -280,7 +280,7 @@ describe('#importFromFilePath()', () => {
       'ExtensibleVSConstraintOnField': EXTENSIBLE,
       'PreferredVSConstraintOnField': PREFERRED,
       'ExampleVSConstraintOnField': EXAMPLE
-    }
+    };
     for (const testCase of Object.keys(answerKey)) {
       const entry = expectAndGetEntry(specifications, 'shr.test', testCase);
       expect(entry.value).to.be.undefined;
@@ -680,6 +680,20 @@ describe('#importFromFilePath()', () => {
     expectCardOne(basedOn.value);
     expectPrimitiveValue(basedOn.value, 'string');
     expectNoConstraints(basedOn.value);
+  });
+
+  it('should correctly import an entry with a zeroed out Value', () => {
+    const specifications = importFixture('ZeroedOutValue');
+    const entry = expectAndGetEntry(specifications, 'shr.test', 'ZeroedOutValue');
+    expect(entry.basedOn).to.have.length(1);
+    expect(entry.basedOn[0].namespace).to.equal('shr.test');
+    expect(entry.basedOn[0].name).to.equal('OptionalValue');
+    expect(entry.concepts).to.be.empty;
+    expect(entry.description).to.be.empty;
+    expect(entry.value).to.be.instanceof(IncompleteValue);
+    expect(entry.value.identifier.isValueKeyWord).to.be.true;
+    expectMinMax(entry.value, 0, 0);
+    expectNoConstraints(entry.value);
   });
 
   it('should correctly import multiple elements in a single namespace', () => {

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -295,6 +295,21 @@ describe('#importFromFilePath()', () => {
     }
   });
 
+  it('should correctly import an entry with a valueset constraint on the Value keyword', () => {
+    const specifications = importFixture('VSConstraintOnValueKeyWord');
+    const entry = expectAndGetEntry(specifications, 'shr.test', 'ChildElement');
+    expect(entry.description).to.be.undefined;
+    expect(entry.value.card).to.be.undefined;
+    expect(entry.value).to.be.instanceof(IncompleteValue);
+    expect(entry.value.identifier.isValueKeyWord).to.be.true;
+    expect(entry.value.constraints).to.have.length(1);
+    expect(entry.value.constraints[0]).to.be.instanceof(ValueSetConstraint);
+    expect(entry.value.constraints[0].path).to.be.empty;
+    expect(entry.value.constraints[0].valueSet).to.equal('http://standardhealthrecord.org/test/vs/Coded');
+    expect(entry.value.constraints[0].bindingStrength).to.equal(REQUIRED);
+    expect(entry.fields).to.be.empty;
+  });
+
   it('should correctly import an entry with a code constraint on the value', () => {
     const specifications = importFixtureFolder('codeConstraints');
     const entry = expectAndGetEntry(specifications, 'shr.test', 'CodeConstraintOnValue');
@@ -317,6 +332,20 @@ describe('#importFromFilePath()', () => {
     expect(entry.value.constraints[0]).to.be.instanceof(CodeConstraint);
     expect(entry.value.constraints[0].path).to.eql([id('shr.core','Coding')]);
     expectConcept(entry.value.constraints[0].code, 'http://foo.org', 'bar', 'FooBar');
+  });
+
+  it('should correctly import an entry with a code constraint on the Value keyword', () => {
+    const specifications = importFixture('CodeConstraintOnValueKeyWord');
+    const entry = expectAndGetEntry(specifications, 'shr.test', 'ChildElement');
+    expect(entry.description).to.be.undefined;
+    expect(entry.value.card).to.be.undefined;
+    expect(entry.value).to.be.instanceof(IncompleteValue);
+    expect(entry.value.identifier.isValueKeyWord).to.be.true;
+    expect(entry.value.constraints).to.have.length(1);
+    expect(entry.value.constraints[0]).to.be.instanceof(CodeConstraint);
+    expect(entry.value.constraints[0].path).to.be.empty;
+    expectConcept(entry.value.constraints[0].code, 'http://foo.org', 'bar', 'FooBar');
+    expect(entry.fields).to.be.empty;
   });
 
   it('should correctly import a group with a code constraint on a field', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,16 +885,16 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.0.0.tgz#ddeefb62d99b630b828401d87e594803d06b9e3b"
+shr-models@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.1.0.tgz#3f9ef0e7ba929ea440fd07f2f31f905866ac4e03"
 
-shr-test-helpers@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.0.tgz#7af44277aa04a988bd3dd75dde55185e2ce34f3b"
+shr-test-helpers@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.1.tgz#72abffcf26606fd5d88f731e3c3d4833210f9d1e"
   dependencies:
     bunyan "^1.8.9"
-    shr-models "^5.0.0"
+    shr-models "^5.1.0"
 
 slice-ansi@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
PR 2/5 in SHR Tool Support for Mapping to Profiles.

The `package.json` file will be updated w/ new version and dependencies once this PR is approved (and _before_ it is merged).  Please review and approve, but do not merge.

This PR supports two main new capabilities:
* Support for referring to `Value` in order to constrain it
* Support for referring to `Entry` in order to constrain it's sub-fields