### PR TITLE
Implemented sanity checking for conflicting versions of shr-models

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const bunyan = require('bunyan');
-const {Specifications} = require('shr-models');
+const {Specifications, MODELS_INFO} = require('shr-models');
 const {Preprocessor, VERSION, GRAMMAR_VERSION} = require('./preprocessor');
 const {DataElementImporter} = require('./dataElementListener');
 const {ValueSetImporter} = require('./valueSetListener');
@@ -121,4 +121,4 @@ class FilesByType {
   }
 }
 
-module.exports = {importFromFilePath, importConfigFromFilePath, VERSION, GRAMMAR_VERSION, setLogger};
+module.exports = {importFromFilePath, importConfigFromFilePath, VERSION, GRAMMAR_VERSION, setLogger, MODELS_INFO};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-text-import",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Imports Standard Health Record (SHR) elements from their custom grammar to the SHR models",
   "author": "",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
   "dependencies": {
     "antlr4": "~4.6.0",
     "bunyan": "^1.8.9",
-    "shr-models": "^5.1.0"
+    "shr-models": "^5.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,6 +889,10 @@ shr-models@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.1.0.tgz#3f9ef0e7ba929ea440fd07f2f31f905866ac4e03"
 
+shr-models@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.0.tgz#3dba6f113f65a16250de2012f6e4d4bbf692e0ed"
+
 shr-test-helpers@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.1.tgz#72abffcf26606fd5d88f731e3c3d4833210f9d1e"


### PR DESCRIPTION
Added sanity checking support for different versions of `shr-models`. Note that although `shr-text-import` uses `shr-test-helpers` as a dev dependency, it doesn't actually use the export portion of test-helpers, so it hasn't been bumped.