### PR TITLE
Fix eslint errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
 # /node_modules/* and /bower_components/* ignored by default
 
 # Ignore ANTLR generated parser files
-lib/text/parsers/*
+lib/parsers/*

--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -292,7 +292,7 @@ class DataElementImporter extends SHRDataElementParserListener {
               logger.error('Fields cannot be constrained to type "Value". ERROR_CODE:11025');
             } else {
               [min, max] = this.getMinMax(typeConstraint.count());
-              const isOnValue = (path.length > 0 && path[0].name == "Value");
+              const isOnValue = (path.length > 0 && path[0].name == 'Value');
               value.addConstraint(new IncludesTypeConstraint(newIdentifier, new Cardinality(min, max), path, isOnValue));
             }
           }

--- a/lib/errorListener.js
+++ b/lib/errorListener.js
@@ -19,7 +19,7 @@ class SHRErrorListener extends ErrorListener {
       return msg;
     }
     
-    msg = `${msg}. ERROR_CODE:${code}`
+    msg = `${msg}. ERROR_CODE:${code}`;
     return msg;
   }
 

--- a/lib/import.js
+++ b/lib/import.js
@@ -19,7 +19,7 @@ function setLogger(bunyanLogger) {
 function importFromFilePath(filePath, configuration=[], specifications = new Specifications()) {
   const filesByType = processPath(filePath);
   const preprocessor = new Preprocessor(configuration);
-  
+
   for (const file of filesByType.dataElement) {
     preprocessor.preprocessFile(file);
   }
@@ -42,15 +42,16 @@ function importConfigFromFilePath(filePath) {
   const filesByType = processPath(filePath);
   const preprocessor = new Preprocessor();
 
-  let defaultConfigPath = path.join(__dirname, "config-template", "/default_config.json")
+  let defaultConfigPath = path.join(__dirname, 'config-template', '/default_config.json');
   let defaultConfigFile = fs.readFileSync(defaultConfigPath, 'utf8');
-  
+
+  let configuration;
   if (filesByType.config.length > 0) {
-    configuration = preprocessor.preprocessConfig(defaultConfigFile, filesByType.config[0])
+    configuration = preprocessor.preprocessConfig(defaultConfigFile, filesByType.config[0]);
   } else {
     configuration = preprocessor.preprocessConfig(defaultConfigFile);
-    fs.writeFileSync(filePath + "/config.json", defaultConfigFile, 'utf8')
-  };
+    fs.writeFileSync(filePath + '/config.json', defaultConfigFile, 'utf8');
+  }
 
   return configuration;
 }
@@ -86,21 +87,21 @@ class FilesByType {
 
   add(file) {
     switch (this.detectType(file)) {
-      case 'DataElement':
-        this._dataElement.push(file);
-        break;
-      case 'Map':
-        this._map.push(file);
-        break;
-      case 'ValueSet':
-        this._valueSet.push(file);
-        break;
-      case 'ContentProfile':
-        this._contentProfile.push(file);
-        break;
-      case 'Config':
-        this._config.push(file);
-        break;
+    case 'DataElement':
+      this._dataElement.push(file);
+      break;
+    case 'Map':
+      this._map.push(file);
+      break;
+    case 'ValueSet':
+      this._valueSet.push(file);
+      break;
+    case 'ContentProfile':
+      this._contentProfile.push(file);
+      break;
+    case 'Config':
+      this._config.push(file);
+      break;
     }
   }
 
@@ -108,14 +109,14 @@ class FilesByType {
     if (!file.endsWith('.txt') && !file.endsWith('.shr') && !file.endsWith('config.json')) {
       return;  // only support *.txt or *.shr or .json coniguration files
     }
-    const re = /^\s*Grammar:\s+([^\s]+)/
-    const lines = fs.readFileSync(file, 'utf-8').split('\n')
+    const re = /^\s*Grammar:\s+([^\s]+)/;
+    const lines = fs.readFileSync(file, 'utf-8').split('\n');
     for (const l of lines) {
       const match = l.match(re);
       if (match != null && match.length >= 2) {
         return match[1];
       } else if (file.endsWith('config.txt') || file.endsWith('config.json')) {
-        return "Config"
+        return 'Config';
       }
     }
   }

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -33,7 +33,7 @@ class Preprocessor extends SHRDataElementParserVisitor {
     if (file != null) {
       try { configFile = JSON.parse(new FileStream(file)); } 
       catch (e) {
-        logger.error("Invalid config file. Should be valid JSON dictionary. ERROR_CODE:11006");
+        logger.error('Invalid config file. Should be valid JSON dictionary. ERROR_CODE:11006');
         return defaults;
       }
     } else {
@@ -44,16 +44,16 @@ class Preprocessor extends SHRDataElementParserVisitor {
     //Fill in config dictionary with default values, if necessary (with some special logic)
     for (var key in defaults) {
       if (configFile[key] == null) {
-        if (key === "fhirURL" && configFile["projectURL"] != null) { //special logic
-          configFile["fhirURL"] = `${configFile["projectURL"]}/fhir`;
+        if (key === 'fhirURL' && configFile['projectURL'] != null) { //special logic
+          configFile['fhirURL'] = `${configFile['projectURL']}/fhir`;
           continue;
         } 
         
         configFile[key] = defaults[key];
-        logger.warn("Configuration file missing key: %s, using default key: %s instead. ERROR_CODE:01002", key, defaults[key]);
+        logger.warn('Configuration file missing key: %s, using default key: %s instead. ERROR_CODE:01002', key, defaults[key]);
       } else {
         //Additional compatibility logic
-        if ( (key === "projectURL" || key === "fhirURL" ) && configFile[key].endsWith('/')) {
+        if ( (key === 'projectURL' || key === 'fhirURL' ) && configFile[key].endsWith('/')) {
           configFile[key] = configFile[key].slice(0, -1);
         }
       }

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -833,122 +833,122 @@ describe('#importFromFilePath()', () => {
   });
 });
 
-describe("#importConfigFromFilePath", () => {
+describe('#importConfigFromFilePath', () => {
   beforeEach(function() {
     err.clear();
   });
 
   it('should correctly import a basic configuration', () => {
-    const configuration = importConfiguration("basicconfig");
-    expect(configuration).to.have.all.keys("projectName","projectShorthand","projectURL","publisher","contact","fhirURL","igIndexContent");
-    expect(configuration.projectName).to.eql("Test Project");
-    expect(configuration.projectShorthand).to.eql("TEST");
-    expect(configuration.projectURL).to.eql("http://test.org");
-    expect(configuration.fhirURL).to.eql("http://test.org/fhir");
-    expect(configuration.igIndexContent).to.eql("basicindexcontent.html");
-    expect(configuration.publisher).to.eql("Test Publisher");
+    const configuration = importConfiguration('basicconfig');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration.projectName).to.eql('Test Project');
+    expect(configuration.projectShorthand).to.eql('TEST');
+    expect(configuration.projectURL).to.eql('http://test.org');
+    expect(configuration.fhirURL).to.eql('http://test.org/fhir');
+    expect(configuration.igIndexContent).to.eql('basicindexcontent.html');
+    expect(configuration.publisher).to.eql('Test Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
-      "telecom": [{
-        "system": "url",
-        "value": "http://test.org"
+      'telecom': [{
+        'system': 'url',
+        'value': 'http://test.org'
       }]
     });
   });
 
   it('should correctly generate missing fhir url from project url when fhir url is missing', () => {
-    const configuration = importConfiguration("incompletefhirconfig");
-    expect(configuration).to.have.all.keys("projectName","projectShorthand","projectURL","publisher","contact","fhirURL","igIndexContent");
-    expect(configuration.projectName).to.eql("Test Project");
-    expect(configuration.projectShorthand).to.eql("TEST");
-    expect(configuration.projectURL).to.eql("http://test.org");
-    expect(configuration.fhirURL).to.eql("http://test.org/fhir");
-    expect(configuration.igIndexContent).to.eql("basicindexcontent.html");
-    expect(configuration.publisher).to.eql("Test Publisher");
+    const configuration = importConfiguration('incompletefhirconfig');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration.projectName).to.eql('Test Project');
+    expect(configuration.projectShorthand).to.eql('TEST');
+    expect(configuration.projectURL).to.eql('http://test.org');
+    expect(configuration.fhirURL).to.eql('http://test.org/fhir');
+    expect(configuration.igIndexContent).to.eql('basicindexcontent.html');
+    expect(configuration.publisher).to.eql('Test Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
-      "telecom": [{
-        "system": "url",
-        "value": "http://test.org"
+      'telecom': [{
+        'system': 'url',
+        'value': 'http://test.org'
       }]
     });
 
   });
 
   it('should correctly use full default configuration when config is empty', () => {
-    const configuration = importConfiguration("emptyconfig");
-    expect(configuration).to.have.all.keys("projectName","projectShorthand","projectURL","publisher","contact","fhirURL","igIndexContent");
-    expect(configuration.projectName).to.eql("Example Project");
-    expect(configuration.projectShorthand).to.eql("EXAMPLE");
-    expect(configuration.projectURL).to.eql("http://example.com");
-    expect(configuration.fhirURL).to.eql("http://example.com/fhir");
-    expect(configuration.igIndexContent).to.eql("exampleIndexContent.html");
-    expect(configuration.publisher).to.eql("Example Publisher");
+    const configuration = importConfiguration('emptyconfig');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration.projectName).to.eql('Example Project');
+    expect(configuration.projectShorthand).to.eql('EXAMPLE');
+    expect(configuration.projectURL).to.eql('http://example.com');
+    expect(configuration.fhirURL).to.eql('http://example.com/fhir');
+    expect(configuration.igIndexContent).to.eql('exampleIndexContent.html');
+    expect(configuration.publisher).to.eql('Example Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
-      "telecom": [{
-        "system": "url",
-        "value": "http://example.com"
+      'telecom': [{
+        'system': 'url',
+        'value': 'http://example.com'
       }]
     });
   });
 
   it('should correctly import an incomplete configuration with partial default data', () => {
-    const configuration = importConfiguration("incompleteconfig");
-    expect(configuration).to.have.all.keys("projectName","projectShorthand","projectURL","publisher","contact","fhirURL","igIndexContent");
-    expect(configuration.projectName).to.eql("Test Project");
-    expect(configuration.projectShorthand).to.eql("EXAMPLE");
-    expect(configuration.projectURL).to.eql("http://example.com");
-    expect(configuration.fhirURL).to.eql("http://example.com/fhir");
-    expect(configuration.igIndexContent).to.eql("exampleIndexContent.html");
-    expect(configuration.publisher).to.eql("Example Publisher");
+    const configuration = importConfiguration('incompleteconfig');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration.projectName).to.eql('Test Project');
+    expect(configuration.projectShorthand).to.eql('EXAMPLE');
+    expect(configuration.projectURL).to.eql('http://example.com');
+    expect(configuration.fhirURL).to.eql('http://example.com/fhir');
+    expect(configuration.igIndexContent).to.eql('exampleIndexContent.html');
+    expect(configuration.publisher).to.eql('Example Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
-      "telecom": [{
-        "system": "url",
-        "value": "http://test.org"
+      'telecom': [{
+        'system': 'url',
+        'value': 'http://test.org'
       }]
     });
   });
 
 
   it('should correctly throw error then use full default configuration when file is not valid JSON', () => {
-    const configuration = importConfiguration("invalidblankconfig", 1);
-    expect(err.errors()[0].msg).to.contain("Invalid config file")
-    expect(configuration).to.have.all.keys("projectName","projectShorthand","projectURL","publisher","contact","fhirURL","igIndexContent");
-    expect(configuration.projectName).to.eql("Example Project");
-    expect(configuration.projectShorthand).to.eql("EXAMPLE");
-    expect(configuration.projectURL).to.eql("http://example.com");
-    expect(configuration.fhirURL).to.eql("http://example.com/fhir");
-    expect(configuration.igIndexContent).to.eql("exampleIndexContent.html");
-    expect(configuration.publisher).to.eql("Example Publisher");
+    const configuration = importConfiguration('invalidblankconfig', 1);
+    expect(err.errors()[0].msg).to.contain('Invalid config file');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration.projectName).to.eql('Example Project');
+    expect(configuration.projectShorthand).to.eql('EXAMPLE');
+    expect(configuration.projectURL).to.eql('http://example.com');
+    expect(configuration.fhirURL).to.eql('http://example.com/fhir');
+    expect(configuration.igIndexContent).to.eql('exampleIndexContent.html');
+    expect(configuration.publisher).to.eql('Example Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
-      "telecom": [{
-        "system": "url",
-        "value": "http://example.com"
+      'telecom': [{
+        'system': 'url',
+        'value': 'http://example.com'
       }]
     });
   });
 
   it('should correctly throw error then use full default configuration when no file exists', () => {
-    const configuration = importConfigurationFolder("emptyfolder");
-    expect(configuration).to.have.all.keys("projectName","projectShorthand","projectURL","publisher","contact","fhirURL","igIndexContent");
-    expect(configuration.projectName).to.eql("Example Project");
-    expect(configuration.projectShorthand).to.eql("EXAMPLE");
-    expect(configuration.projectURL).to.eql("http://example.com");
-    expect(configuration.fhirURL).to.eql("http://example.com/fhir");
-    expect(configuration.igIndexContent).to.eql("exampleIndexContent.html");
-    expect(configuration.publisher).to.eql("Example Publisher");
+    const configuration = importConfigurationFolder('emptyfolder');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration.projectName).to.eql('Example Project');
+    expect(configuration.projectShorthand).to.eql('EXAMPLE');
+    expect(configuration.projectURL).to.eql('http://example.com');
+    expect(configuration.fhirURL).to.eql('http://example.com/fhir');
+    expect(configuration.igIndexContent).to.eql('exampleIndexContent.html');
+    expect(configuration.publisher).to.eql('Example Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
-      "telecom": [{
-        "system": "url",
-        "value": "http://example.com"
+      'telecom': [{
+        'system': 'url',
+        'value': 'http://example.com'
       }]
     });
   });
-})
+});
 
 // Shorthand Identifier constructor for more concise code
 function id(namespace, name) {


### PR DESCRIPTION
This fixes a bunch of errors reported by eslint, making the code more consistent across the project.

Most errors are related to using `"` instead of `'` for strings.  Some are missing `;` at the end of statements.  And one was use of an undefined variable.