### PR TITLE
 Support "value is type $primitive" for constraining choices

### DIFF
--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -116,7 +116,7 @@ class DataElementImporter extends SHRDataElementParserListener {
   enterEntryDef(ctx) {
     const id = new Identifier(this._currentNs, ctx.entryHeader().simpleName().getText());
     this._currentDef = new DataElement(id, true).withGrammarVersion(this._currentGrammarVersion);
-    
+
     if (ctx.entryHeader().simpleName().LOWER_WORD()) { logger.error('Entry Element name "%s" should begin with a capital letter. ERROR_CODE:11002', ctx.entryHeader().simpleName().getText()); }
   }
 
@@ -460,7 +460,9 @@ class DataElementImporter extends SHRDataElementParserListener {
       return this.resolveToIdentifier(ctx.simpleOrFQName().getText());
     } else if (typeof ctx.ref === 'function' && ctx.ref()) {
       return this.resolveToIdentifier(ctx.ref().simpleOrFQName().getText());
-    }else if (ctx.tbd() && ctx.tbd().STRING()) {
+    } else if (typeof ctx.primitive === 'function' && ctx.primitive()) {
+      return new PrimitiveIdentifier(ctx.primitive().getText());
+    } else if (ctx.tbd() && ctx.tbd().STRING()) {
       return new TBD(stripDelimitersFromToken(ctx.tbd().STRING()));
     } else {
       return new TBD();

--- a/lib/parsers/SHRDataElementParser.js
+++ b/lib/parsers/SHRDataElementParser.js
@@ -7,7 +7,7 @@ var SHRDataElementParserVisitor = require('./SHRDataElementParserVisitor').SHRDa
 var grammarFileName = "SHRDataElementParser.g4";
 
 var serializedATN = ["\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd",
-    "\3H\u01a2\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4",
+    "\3H\u01a4\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4",
     "\t\t\t\4\n\t\n\4\13\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t",
     "\20\4\21\t\21\4\22\t\22\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27",
     "\t\27\4\30\t\30\4\31\t\31\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4",
@@ -30,74 +30,74 @@ var serializedATN = ["\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd",
     "\u0105\n\27\3\30\3\30\3\30\7\30\u010a\n\30\f\30\16\30\u010d\13\30\3",
     "\31\3\31\3\31\3\32\3\32\3\32\3\32\3\33\3\33\3\34\3\34\3\35\3\35\3\36",
     "\3\36\5\36\u011e\n\36\3\37\3\37\3\37\3\37\3\37\3 \3 \5 \u0127\n \3!",
-    "\3!\3!\5!\u012c\n!\3\"\3\"\5\"\u0130\n\"\3#\3#\3$\3$\3$\3$\5$\u0138",
-    "\n$\3%\3%\3%\5%\u013d\n%\3%\5%\u0140\n%\3&\3&\3&\6&\u0145\n&\r&\16&",
-    "\u0146\3&\3&\5&\u014b\n&\3&\3&\7&\u014f\n&\f&\16&\u0152\13&\3&\3&\5",
-    "&\u0156\n&\3\'\3\'\3\'\3\'\3\'\3\'\3\'\5\'\u015f\n\'\3(\3(\3(\5(\u0164",
-    "\n(\3)\5)\u0167\n)\3)\5)\u016a\n)\3)\3)\3)\5)\u016f\n)\3*\3*\3*\3+\3",
-    "+\6+\u0176\n+\r+\16+\u0177\3,\3,\3,\3-\3-\3-\3-\5-\u0181\n-\3.\3.\6",
-    ".\u0185\n.\r.\16.\u0186\3/\3/\3/\3/\3\60\3\60\3\60\3\60\3\60\5\60\u0192",
-    "\n\60\3\61\3\61\3\62\3\62\3\62\3\62\3\63\3\63\5\63\u019c\n\63\3\64\3",
-    "\64\5\64\u01a0\n\64\3\64\2\2\65\2\4\6\b\n\f\16\20\22\24\26\30\32\34",
-    "\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`bdf\2\n\4\2((*+\3\2AB",
-    "\3\2?A\3\2\23\25\3\2\35\36\3\2\32\33\3\2-=\4\2$$>>\u01b2\2h\3\2\2\2",
-    "\4w\3\2\2\2\6}\3\2\2\2\b\u0087\3\2\2\2\n\u008b\3\2\2\2\f\u0091\3\2\2",
-    "\2\16\u0095\3\2\2\2\20\u009d\3\2\2\2\22\u00a2\3\2\2\2\24\u00a4\3\2\2",
-    "\2\26\u00ab\3\2\2\2\30\u00b0\3\2\2\2\32\u00b6\3\2\2\2\34\u00ba\3\2\2",
-    "\2\36\u00c1\3\2\2\2 \u00c4\3\2\2\2\"\u00cc\3\2\2\2$\u00e3\3\2\2\2&\u00e6",
-    "\3\2\2\2(\u00fa\3\2\2\2*\u00fc\3\2\2\2,\u0101\3\2\2\2.\u0106\3\2\2\2",
-    "\60\u010e\3\2\2\2\62\u0111\3\2\2\2\64\u0115\3\2\2\2\66\u0117\3\2\2\2",
-    "8\u0119\3\2\2\2:\u011d\3\2\2\2<\u011f\3\2\2\2>\u0124\3\2\2\2@\u012b",
-    "\3\2\2\2B\u012f\3\2\2\2D\u0131\3\2\2\2F\u0133\3\2\2\2H\u013c\3\2\2\2",
-    "J\u0141\3\2\2\2L\u015e\3\2\2\2N\u0160\3\2\2\2P\u0166\3\2\2\2R\u0170",
-    "\3\2\2\2T\u0175\3\2\2\2V\u0179\3\2\2\2X\u017c\3\2\2\2Z\u0184\3\2\2\2",
-    "\\\u0188\3\2\2\2^\u0191\3\2\2\2`\u0193\3\2\2\2b\u0195\3\2\2\2d\u0199",
-    "\3\2\2\2f\u019d\3\2\2\2hj\5\4\3\2ik\5\60\31\2ji\3\2\2\2jk\3\2\2\2km",
-    "\3\2\2\2ln\5\6\4\2ml\3\2\2\2mn\3\2\2\2np\3\2\2\2oq\5\b\5\2po\3\2\2\2",
-    "pq\3\2\2\2qs\3\2\2\2rt\5\f\7\2sr\3\2\2\2st\3\2\2\2tu\3\2\2\2uv\5\20",
-    "\t\2v\3\3\2\2\2wx\7\3\2\2xy\7\4\2\2yz\5\62\32\2z{\7\5\2\2{|\5\64\33",
-    "\2|\5\3\2\2\2}~\7\6\2\2~\u0083\5\64\33\2\177\u0080\7#\2\2\u0080\u0082",
-    "\5\64\33\2\u0081\177\3\2\2\2\u0082\u0085\3\2\2\2\u0083\u0081\3\2\2\2",
-    "\u0083\u0084\3\2\2\2\u0084\7\3\2\2\2\u0085\u0083\3\2\2\2\u0086\u0088",
-    "\5\n\6\2\u0087\u0086\3\2\2\2\u0088\u0089\3\2\2\2\u0089\u0087\3\2\2\2",
-    "\u0089\u008a\3\2\2\2\u008a\t\3\2\2\2\u008b\u008c\7\7\2\2\u008c\u008d",
-    "\7?\2\2\u008d\u008e\7\"\2\2\u008e\u008f\7(\2\2\u008f\13\3\2\2\2\u0090",
-    "\u0092\5\16\b\2\u0091\u0090\3\2\2\2\u0092\u0093\3\2\2\2\u0093\u0091",
-    "\3\2\2\2\u0093\u0094\3\2\2\2\u0094\r\3\2\2\2\u0095\u0096\7\b\2\2\u0096",
-    "\u0097\7?\2\2\u0097\u0098\7\"\2\2\u0098\u0099\t\2\2\2\u0099\17\3\2\2",
-    "\2\u009a\u009c\5\22\n\2\u009b\u009a\3\2\2\2\u009c\u009f\3\2\2\2\u009d",
-    "\u009b\3\2\2\2\u009d\u009e\3\2\2\2\u009e\21\3\2\2\2\u009f\u009d\3\2",
-    "\2\2\u00a0\u00a3\5\24\13\2\u00a1\u00a3\5\30\r\2\u00a2\u00a0\3\2\2\2",
-    "\u00a2\u00a1\3\2\2\2\u00a3\23\3\2\2\2\u00a4\u00a6\5\26\f\2\u00a5\u00a7",
-    "\5\34\17\2\u00a6\u00a5\3\2\2\2\u00a6\u00a7\3\2\2\2\u00a7\u00a8\3\2\2",
-    "\2\u00a8\u00a9\5 \21\2\u00a9\25\3\2\2\2\u00aa\u00ac\7\t\2\2\u00ab\u00aa",
-    "\3\2\2\2\u00ab\u00ac\3\2\2\2\u00ac\u00ad\3\2\2\2\u00ad\u00ae\7\n\2\2",
-    "\u00ae\u00af\5\66\34\2\u00af\27\3\2\2\2\u00b0\u00b2\5\32\16\2\u00b1",
-    "\u00b3\5\34\17\2\u00b2\u00b1\3\2\2\2\u00b2\u00b3\3\2\2\2\u00b3\u00b4",
-    "\3\2\2\2\u00b4\u00b5\5 \21\2\u00b5\31\3\2\2\2\u00b6\u00b7\7\13\2\2\u00b7",
-    "\u00b8\5\66\34\2\u00b8\33\3\2\2\2\u00b9\u00bb\5\36\20\2\u00ba\u00b9",
-    "\3\2\2\2\u00bb\u00bc\3\2\2\2\u00bc\u00ba\3\2\2\2\u00bc\u00bd\3\2\2\2",
-    "\u00bd\35\3\2\2\2\u00be\u00c2\5*\26\2\u00bf\u00c2\5,\27\2\u00c0\u00c2",
-    "\5\60\31\2\u00c1\u00be\3\2\2\2\u00c1\u00bf\3\2\2\2\u00c1\u00c0\3\2\2",
-    "\2\u00c2\37\3\2\2\2\u00c3\u00c5\5\"\22\2\u00c4\u00c3\3\2\2\2\u00c4\u00c5",
-    "\3\2\2\2\u00c5\u00c9\3\2\2\2\u00c6\u00c8\5&\24\2\u00c7\u00c6\3\2\2\2",
-    "\u00c8\u00cb\3\2\2\2\u00c9\u00c7\3\2\2\2\u00c9\u00ca\3\2\2\2\u00ca!",
-    "\3\2\2\2\u00cb\u00c9\3\2\2\2\u00cc\u00ce\7\r\2\2\u00cd\u00cf\5b\62\2",
-    "\u00ce\u00cd\3\2\2\2\u00ce\u00cf\3\2\2\2\u00cf\u00d1\3\2\2\2\u00d0\u00d2",
-    "\7%\2\2\u00d1\u00d0\3\2\2\2\u00d1\u00d2\3\2\2\2\u00d2\u00d3\3\2\2\2",
-    "\u00d3\u00d8\5$\23\2\u00d4\u00d5\7\21\2\2\u00d5\u00d7\5$\23\2\u00d6",
-    "\u00d4\3\2\2\2\u00d7\u00da\3\2\2\2\u00d8\u00d6\3\2\2\2\u00d8\u00d9\3",
-    "\2\2\2\u00d9\u00dc\3\2\2\2\u00da\u00d8\3\2\2\2\u00db\u00dd\7&\2\2\u00dc",
-    "\u00db\3\2\2\2\u00dc\u00dd\3\2\2\2\u00dd#\3\2\2\2\u00de\u00e4\5:\36",
-    "\2\u00df\u00e4\5<\37\2\u00e0\u00e4\5`\61\2\u00e1\u00e4\5H%\2\u00e2\u00e4",
-    "\5d\63\2\u00e3\u00de\3\2\2\2\u00e3\u00df\3\2\2\2\u00e3\u00e0\3\2\2\2",
-    "\u00e3\u00e1\3\2\2\2\u00e3\u00e2\3\2\2\2\u00e4%\3\2\2\2\u00e5\u00e7",
-    "\5b\62\2\u00e6\u00e5\3\2\2\2\u00e6\u00e7\3\2\2\2\u00e7\u00e9\3\2\2\2",
-    "\u00e8\u00ea\7%\2\2\u00e9\u00e8\3\2\2\2\u00e9\u00ea\3\2\2\2\u00ea\u00eb",
-    "\3\2\2\2\u00eb\u00f0\5(\25\2\u00ec\u00ed\7\21\2\2\u00ed\u00ef\5(\25",
-    "\2\u00ee\u00ec\3\2\2\2\u00ef\u00f2\3\2\2\2\u00f0\u00ee\3\2\2\2\u00f0",
-    "\u00f1\3\2\2\2\u00f1\u00f4\3\2\2\2\u00f2\u00f0\3\2\2\2\u00f3\u00f5\7",
-    "&\2\2\u00f4\u00f3\3\2\2\2\u00f4\u00f5\3\2\2\2\u00f5\'\3\2\2\2\u00f6",
+    "\3!\3!\5!\u012c\n!\3\"\3\"\5\"\u0130\n\"\3#\3#\3$\3$\3$\3$\3$\5$\u0139",
+    "\n$\3%\3%\3%\5%\u013e\n%\3%\5%\u0141\n%\3&\3&\3&\6&\u0146\n&\r&\16&",
+    "\u0147\3&\3&\5&\u014c\n&\3&\3&\7&\u0150\n&\f&\16&\u0153\13&\3&\3&\5",
+    "&\u0157\n&\3\'\3\'\3\'\3\'\3\'\3\'\3\'\5\'\u0160\n\'\3(\3(\3(\5(\u0165",
+    "\n(\3)\5)\u0168\n)\3)\5)\u016b\n)\3)\3)\3)\5)\u0170\n)\3*\3*\3*\3+\3",
+    "+\6+\u0177\n+\r+\16+\u0178\3,\3,\3,\3-\3-\3-\3-\3-\5-\u0183\n-\3.\3",
+    ".\6.\u0187\n.\r.\16.\u0188\3/\3/\3/\3/\3\60\3\60\3\60\3\60\3\60\5\60",
+    "\u0194\n\60\3\61\3\61\3\62\3\62\3\62\3\62\3\63\3\63\5\63\u019e\n\63",
+    "\3\64\3\64\5\64\u01a2\n\64\3\64\2\2\65\2\4\6\b\n\f\16\20\22\24\26\30",
+    "\32\34\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRTVXZ\\^`bdf\2\n\4\2((*+",
+    "\3\2AB\3\2?A\3\2\23\25\3\2\35\36\3\2\32\33\3\2-=\4\2$$>>\u01b6\2h\3",
+    "\2\2\2\4w\3\2\2\2\6}\3\2\2\2\b\u0087\3\2\2\2\n\u008b\3\2\2\2\f\u0091",
+    "\3\2\2\2\16\u0095\3\2\2\2\20\u009d\3\2\2\2\22\u00a2\3\2\2\2\24\u00a4",
+    "\3\2\2\2\26\u00ab\3\2\2\2\30\u00b0\3\2\2\2\32\u00b6\3\2\2\2\34\u00ba",
+    "\3\2\2\2\36\u00c1\3\2\2\2 \u00c4\3\2\2\2\"\u00cc\3\2\2\2$\u00e3\3\2",
+    "\2\2&\u00e6\3\2\2\2(\u00fa\3\2\2\2*\u00fc\3\2\2\2,\u0101\3\2\2\2.\u0106",
+    "\3\2\2\2\60\u010e\3\2\2\2\62\u0111\3\2\2\2\64\u0115\3\2\2\2\66\u0117",
+    "\3\2\2\28\u0119\3\2\2\2:\u011d\3\2\2\2<\u011f\3\2\2\2>\u0124\3\2\2\2",
+    "@\u012b\3\2\2\2B\u012f\3\2\2\2D\u0131\3\2\2\2F\u0133\3\2\2\2H\u013d",
+    "\3\2\2\2J\u0142\3\2\2\2L\u015f\3\2\2\2N\u0161\3\2\2\2P\u0167\3\2\2\2",
+    "R\u0171\3\2\2\2T\u0176\3\2\2\2V\u017a\3\2\2\2X\u017d\3\2\2\2Z\u0186",
+    "\3\2\2\2\\\u018a\3\2\2\2^\u0193\3\2\2\2`\u0195\3\2\2\2b\u0197\3\2\2",
+    "\2d\u019b\3\2\2\2f\u019f\3\2\2\2hj\5\4\3\2ik\5\60\31\2ji\3\2\2\2jk\3",
+    "\2\2\2km\3\2\2\2ln\5\6\4\2ml\3\2\2\2mn\3\2\2\2np\3\2\2\2oq\5\b\5\2p",
+    "o\3\2\2\2pq\3\2\2\2qs\3\2\2\2rt\5\f\7\2sr\3\2\2\2st\3\2\2\2tu\3\2\2",
+    "\2uv\5\20\t\2v\3\3\2\2\2wx\7\3\2\2xy\7\4\2\2yz\5\62\32\2z{\7\5\2\2{",
+    "|\5\64\33\2|\5\3\2\2\2}~\7\6\2\2~\u0083\5\64\33\2\177\u0080\7#\2\2\u0080",
+    "\u0082\5\64\33\2\u0081\177\3\2\2\2\u0082\u0085\3\2\2\2\u0083\u0081\3",
+    "\2\2\2\u0083\u0084\3\2\2\2\u0084\7\3\2\2\2\u0085\u0083\3\2\2\2\u0086",
+    "\u0088\5\n\6\2\u0087\u0086\3\2\2\2\u0088\u0089\3\2\2\2\u0089\u0087\3",
+    "\2\2\2\u0089\u008a\3\2\2\2\u008a\t\3\2\2\2\u008b\u008c\7\7\2\2\u008c",
+    "\u008d\7?\2\2\u008d\u008e\7\"\2\2\u008e\u008f\7(\2\2\u008f\13\3\2\2",
+    "\2\u0090\u0092\5\16\b\2\u0091\u0090\3\2\2\2\u0092\u0093\3\2\2\2\u0093",
+    "\u0091\3\2\2\2\u0093\u0094\3\2\2\2\u0094\r\3\2\2\2\u0095\u0096\7\b\2",
+    "\2\u0096\u0097\7?\2\2\u0097\u0098\7\"\2\2\u0098\u0099\t\2\2\2\u0099",
+    "\17\3\2\2\2\u009a\u009c\5\22\n\2\u009b\u009a\3\2\2\2\u009c\u009f\3\2",
+    "\2\2\u009d\u009b\3\2\2\2\u009d\u009e\3\2\2\2\u009e\21\3\2\2\2\u009f",
+    "\u009d\3\2\2\2\u00a0\u00a3\5\24\13\2\u00a1\u00a3\5\30\r\2\u00a2\u00a0",
+    "\3\2\2\2\u00a2\u00a1\3\2\2\2\u00a3\23\3\2\2\2\u00a4\u00a6\5\26\f\2\u00a5",
+    "\u00a7\5\34\17\2\u00a6\u00a5\3\2\2\2\u00a6\u00a7\3\2\2\2\u00a7\u00a8",
+    "\3\2\2\2\u00a8\u00a9\5 \21\2\u00a9\25\3\2\2\2\u00aa\u00ac\7\t\2\2\u00ab",
+    "\u00aa\3\2\2\2\u00ab\u00ac\3\2\2\2\u00ac\u00ad\3\2\2\2\u00ad\u00ae\7",
+    "\n\2\2\u00ae\u00af\5\66\34\2\u00af\27\3\2\2\2\u00b0\u00b2\5\32\16\2",
+    "\u00b1\u00b3\5\34\17\2\u00b2\u00b1\3\2\2\2\u00b2\u00b3\3\2\2\2\u00b3",
+    "\u00b4\3\2\2\2\u00b4\u00b5\5 \21\2\u00b5\31\3\2\2\2\u00b6\u00b7\7\13",
+    "\2\2\u00b7\u00b8\5\66\34\2\u00b8\33\3\2\2\2\u00b9\u00bb\5\36\20\2\u00ba",
+    "\u00b9\3\2\2\2\u00bb\u00bc\3\2\2\2\u00bc\u00ba\3\2\2\2\u00bc\u00bd\3",
+    "\2\2\2\u00bd\35\3\2\2\2\u00be\u00c2\5*\26\2\u00bf\u00c2\5,\27\2\u00c0",
+    "\u00c2\5\60\31\2\u00c1\u00be\3\2\2\2\u00c1\u00bf\3\2\2\2\u00c1\u00c0",
+    "\3\2\2\2\u00c2\37\3\2\2\2\u00c3\u00c5\5\"\22\2\u00c4\u00c3\3\2\2\2\u00c4",
+    "\u00c5\3\2\2\2\u00c5\u00c9\3\2\2\2\u00c6\u00c8\5&\24\2\u00c7\u00c6\3",
+    "\2\2\2\u00c8\u00cb\3\2\2\2\u00c9\u00c7\3\2\2\2\u00c9\u00ca\3\2\2\2\u00ca",
+    "!\3\2\2\2\u00cb\u00c9\3\2\2\2\u00cc\u00ce\7\r\2\2\u00cd\u00cf\5b\62",
+    "\2\u00ce\u00cd\3\2\2\2\u00ce\u00cf\3\2\2\2\u00cf\u00d1\3\2\2\2\u00d0",
+    "\u00d2\7%\2\2\u00d1\u00d0\3\2\2\2\u00d1\u00d2\3\2\2\2\u00d2\u00d3\3",
+    "\2\2\2\u00d3\u00d8\5$\23\2\u00d4\u00d5\7\21\2\2\u00d5\u00d7\5$\23\2",
+    "\u00d6\u00d4\3\2\2\2\u00d7\u00da\3\2\2\2\u00d8\u00d6\3\2\2\2\u00d8\u00d9",
+    "\3\2\2\2\u00d9\u00dc\3\2\2\2\u00da\u00d8\3\2\2\2\u00db\u00dd\7&\2\2",
+    "\u00dc\u00db\3\2\2\2\u00dc\u00dd\3\2\2\2\u00dd#\3\2\2\2\u00de\u00e4",
+    "\5:\36\2\u00df\u00e4\5<\37\2\u00e0\u00e4\5`\61\2\u00e1\u00e4\5H%\2\u00e2",
+    "\u00e4\5d\63\2\u00e3\u00de\3\2\2\2\u00e3\u00df\3\2\2\2\u00e3\u00e0\3",
+    "\2\2\2\u00e3\u00e1\3\2\2\2\u00e3\u00e2\3\2\2\2\u00e4%\3\2\2\2\u00e5",
+    "\u00e7\5b\62\2\u00e6\u00e5\3\2\2\2\u00e6\u00e7\3\2\2\2\u00e7\u00e9\3",
+    "\2\2\2\u00e8\u00ea\7%\2\2\u00e9\u00e8\3\2\2\2\u00e9\u00ea\3\2\2\2\u00ea",
+    "\u00eb\3\2\2\2\u00eb\u00f0\5(\25\2\u00ec\u00ed\7\21\2\2\u00ed\u00ef",
+    "\5(\25\2\u00ee\u00ec\3\2\2\2\u00ef\u00f2\3\2\2\2\u00f0\u00ee\3\2\2\2",
+    "\u00f0\u00f1\3\2\2\2\u00f1\u00f4\3\2\2\2\u00f2\u00f0\3\2\2\2\u00f3\u00f5",
+    "\7&\2\2\u00f4\u00f3\3\2\2\2\u00f4\u00f5\3\2\2\2\u00f5\'\3\2\2\2\u00f6",
     "\u00fb\5:\36\2\u00f7\u00fb\5<\37\2\u00f8\u00fb\5H%\2\u00f9\u00fb\5d",
     "\63\2\u00fa\u00f6\3\2\2\2\u00fa\u00f7\3\2\2\2\u00fa\u00f8\3\2\2\2\u00fa",
     "\u00f9\3\2\2\2\u00fb)\3\2\2\2\u00fc\u00ff\7\f\2\2\u00fd\u0100\5:\36",
@@ -117,50 +117,51 @@ var serializedATN = ["\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd",
     "\u0128\u0129\7?\2\2\u0129\u012c\5> \2\u012a\u012c\5f\64\2\u012b\u0128",
     "\3\2\2\2\u012b\u012a\3\2\2\2\u012cA\3\2\2\2\u012d\u0130\5@!\2\u012e",
     "\u0130\5> \2\u012f\u012d\3\2\2\2\u012f\u012e\3\2\2\2\u0130C\3\2\2\2",
-    "\u0131\u0132\t\5\2\2\u0132E\3\2\2\2\u0133\u0137\5b\62\2\u0134\u0138",
-    "\5:\36\2\u0135\u0138\5<\37\2\u0136\u0138\5d\63\2\u0137\u0134\3\2\2\2",
-    "\u0137\u0135\3\2\2\2\u0137\u0136\3\2\2\2\u0138G\3\2\2\2\u0139\u013d",
-    "\5:\36\2\u013a\u013d\5J&\2\u013b\u013d\5`\61\2\u013c\u0139\3\2\2\2\u013c",
-    "\u013a\3\2\2\2\u013c\u013b\3\2\2\2\u013d\u013f\3\2\2\2\u013e\u0140\5",
-    "L\'\2\u013f\u013e\3\2\2\2\u013f\u0140\3\2\2\2\u0140I\3\2\2\2\u0141\u0155",
-    "\5:\36\2\u0142\u0143\7!\2\2\u0143\u0145\5\66\34\2\u0144\u0142\3\2\2",
-    "\2\u0145\u0146\3\2\2\2\u0146\u0144\3\2\2\2\u0146\u0147\3\2\2\2\u0147",
-    "\u014a\3\2\2\2\u0148\u0149\7!\2\2\u0149\u014b\5`\61\2\u014a\u0148\3",
-    "\2\2\2\u014a\u014b\3\2\2\2\u014b\u0156\3\2\2\2\u014c\u014d\7!\2\2\u014d",
-    "\u014f\5\66\34\2\u014e\u014c\3\2\2\2\u014f\u0152\3\2\2\2\u0150\u014e",
-    "\3\2\2\2\u0150\u0151\3\2\2\2\u0151\u0153\3\2\2\2\u0152\u0150\3\2\2\2",
-    "\u0153\u0154\7!\2\2\u0154\u0156\5`\61\2\u0155\u0144\3\2\2\2\u0155\u0150",
-    "\3\2\2\2\u0156K\3\2\2\2\u0157\u015f\5P)\2\u0158\u015f\5R*\2\u0159\u015f",
-    "\5T+\2\u015a\u015f\5V,\2\u015b\u015f\5X-\2\u015c\u015f\5Z.\2\u015d\u015f",
-    "\5\\/\2\u015e\u0157\3\2\2\2\u015e\u0158\3\2\2\2\u015e\u0159\3\2\2\2",
-    "\u015e\u015a\3\2\2\2\u015e\u015b\3\2\2\2\u015e\u015c\3\2\2\2\u015e\u015d",
-    "\3\2\2\2\u015fM\3\2\2\2\u0160\u0163\7\22\2\2\u0161\u0164\7\67\2\2\u0162",
-    "\u0164\5:\36\2\u0163\u0161\3\2\2\2\u0163\u0162\3\2\2\2\u0164O\3\2\2",
-    "\2\u0165\u0167\5N(\2\u0166\u0165\3\2\2\2\u0166\u0167\3\2\2\2\u0167\u0169",
-    "\3\2\2\2\u0168\u016a\5D#\2\u0169\u0168\3\2\2\2\u0169\u016a\3\2\2\2\u016a",
-    "\u016b\3\2\2\2\u016b\u016c\7\27\2\2\u016c\u016e\5^\60\2\u016d\u016f",
-    "\7\26\2\2\u016e\u016d\3\2\2\2\u016e\u016f\3\2\2\2\u016fQ\3\2\2\2\u0170",
-    "\u0171\7\31\2\2\u0171\u0172\5B\"\2\u0172S\3\2\2\2\u0173\u0174\7\34\2",
-    "\2\u0174\u0176\5B\"\2\u0175\u0173\3\2\2\2\u0176\u0177\3\2\2\2\u0177",
-    "\u0175\3\2\2\2\u0177\u0178\3\2\2\2\u0178U\3\2\2\2\u0179\u017a\7\31\2",
-    "\2\u017a\u017b\t\6\2\2\u017bW\3\2\2\2\u017c\u0180\t\7\2\2\u017d\u0181",
-    "\5:\36\2\u017e\u0181\5<\37\2\u017f\u0181\5d\63\2\u0180\u017d\3\2\2\2",
-    "\u0180\u017e\3\2\2\2\u0180\u017f\3\2\2\2\u0181Y\3\2\2\2\u0182\u0183",
-    "\7\34\2\2\u0183\u0185\5F$\2\u0184\u0182\3\2\2\2\u0185\u0186\3\2\2\2",
-    "\u0186\u0184\3\2\2\2\u0186\u0187\3\2\2\2\u0187[\3\2\2\2\u0188\u0189",
-    "\7\22\2\2\u0189\u018a\7\30\2\2\u018a\u018b\5@!\2\u018b]\3\2\2\2\u018c",
-    "\u0192\7(\2\2\u018d\u0192\7)\2\2\u018e\u0192\7*\2\2\u018f\u0192\5\66",
-    "\34\2\u0190\u0192\5d\63\2\u0191\u018c\3\2\2\2\u0191\u018d\3\2\2\2\u0191",
-    "\u018e\3\2\2\2\u0191\u018f\3\2\2\2\u0191\u0190\3\2\2\2\u0192_\3\2\2",
-    "\2\u0193\u0194\t\b\2\2\u0194a\3\2\2\2\u0195\u0196\7>\2\2\u0196\u0197",
-    "\7\'\2\2\u0197\u0198\t\t\2\2\u0198c\3\2\2\2\u0199\u019b\7\37\2\2\u019a",
-    "\u019c\7D\2\2\u019b\u019a\3\2\2\2\u019b\u019c\3\2\2\2\u019ce\3\2\2\2",
-    "\u019d\u019f\7 \2\2\u019e\u01a0\7D\2\2\u019f\u019e\3\2\2\2\u019f\u01a0",
-    "\3\2\2\2\u01a0g\3\2\2\2\65jmps\u0083\u0089\u0093\u009d\u00a2\u00a6\u00ab",
-    "\u00b2\u00bc\u00c1\u00c4\u00c9\u00ce\u00d1\u00d8\u00dc\u00e3\u00e6\u00e9",
-    "\u00f0\u00f4\u00fa\u00ff\u0104\u010b\u011d\u0126\u012b\u012f\u0137\u013c",
-    "\u013f\u0146\u014a\u0150\u0155\u015e\u0163\u0166\u0169\u016e\u0177\u0180",
-    "\u0186\u0191\u019b\u019f"].join("");
+    "\u0131\u0132\t\5\2\2\u0132E\3\2\2\2\u0133\u0138\5b\62\2\u0134\u0139",
+    "\5:\36\2\u0135\u0139\5<\37\2\u0136\u0139\5`\61\2\u0137\u0139\5d\63\2",
+    "\u0138\u0134\3\2\2\2\u0138\u0135\3\2\2\2\u0138\u0136\3\2\2\2\u0138\u0137",
+    "\3\2\2\2\u0139G\3\2\2\2\u013a\u013e\5:\36\2\u013b\u013e\5J&\2\u013c",
+    "\u013e\5`\61\2\u013d\u013a\3\2\2\2\u013d\u013b\3\2\2\2\u013d\u013c\3",
+    "\2\2\2\u013e\u0140\3\2\2\2\u013f\u0141\5L\'\2\u0140\u013f\3\2\2\2\u0140",
+    "\u0141\3\2\2\2\u0141I\3\2\2\2\u0142\u0156\5:\36\2\u0143\u0144\7!\2\2",
+    "\u0144\u0146\5\66\34\2\u0145\u0143\3\2\2\2\u0146\u0147\3\2\2\2\u0147",
+    "\u0145\3\2\2\2\u0147\u0148\3\2\2\2\u0148\u014b\3\2\2\2\u0149\u014a\7",
+    "!\2\2\u014a\u014c\5`\61\2\u014b\u0149\3\2\2\2\u014b\u014c\3\2\2\2\u014c",
+    "\u0157\3\2\2\2\u014d\u014e\7!\2\2\u014e\u0150\5\66\34\2\u014f\u014d",
+    "\3\2\2\2\u0150\u0153\3\2\2\2\u0151\u014f\3\2\2\2\u0151\u0152\3\2\2\2",
+    "\u0152\u0154\3\2\2\2\u0153\u0151\3\2\2\2\u0154\u0155\7!\2\2\u0155\u0157",
+    "\5`\61\2\u0156\u0145\3\2\2\2\u0156\u0151\3\2\2\2\u0157K\3\2\2\2\u0158",
+    "\u0160\5P)\2\u0159\u0160\5R*\2\u015a\u0160\5T+\2\u015b\u0160\5V,\2\u015c",
+    "\u0160\5X-\2\u015d\u0160\5Z.\2\u015e\u0160\5\\/\2\u015f\u0158\3\2\2",
+    "\2\u015f\u0159\3\2\2\2\u015f\u015a\3\2\2\2\u015f\u015b\3\2\2\2\u015f",
+    "\u015c\3\2\2\2\u015f\u015d\3\2\2\2\u015f\u015e\3\2\2\2\u0160M\3\2\2",
+    "\2\u0161\u0164\7\22\2\2\u0162\u0165\7\67\2\2\u0163\u0165\5:\36\2\u0164",
+    "\u0162\3\2\2\2\u0164\u0163\3\2\2\2\u0165O\3\2\2\2\u0166\u0168\5N(\2",
+    "\u0167\u0166\3\2\2\2\u0167\u0168\3\2\2\2\u0168\u016a\3\2\2\2\u0169\u016b",
+    "\5D#\2\u016a\u0169\3\2\2\2\u016a\u016b\3\2\2\2\u016b\u016c\3\2\2\2\u016c",
+    "\u016d\7\27\2\2\u016d\u016f\5^\60\2\u016e\u0170\7\26\2\2\u016f\u016e",
+    "\3\2\2\2\u016f\u0170\3\2\2\2\u0170Q\3\2\2\2\u0171\u0172\7\31\2\2\u0172",
+    "\u0173\5B\"\2\u0173S\3\2\2\2\u0174\u0175\7\34\2\2\u0175\u0177\5B\"\2",
+    "\u0176\u0174\3\2\2\2\u0177\u0178\3\2\2\2\u0178\u0176\3\2\2\2\u0178\u0179",
+    "\3\2\2\2\u0179U\3\2\2\2\u017a\u017b\7\31\2\2\u017b\u017c\t\6\2\2\u017c",
+    "W\3\2\2\2\u017d\u0182\t\7\2\2\u017e\u0183\5:\36\2\u017f\u0183\5<\37",
+    "\2\u0180\u0183\5`\61\2\u0181\u0183\5d\63\2\u0182\u017e\3\2\2\2\u0182",
+    "\u017f\3\2\2\2\u0182\u0180\3\2\2\2\u0182\u0181\3\2\2\2\u0183Y\3\2\2",
+    "\2\u0184\u0185\7\34\2\2\u0185\u0187\5F$\2\u0186\u0184\3\2\2\2\u0187",
+    "\u0188\3\2\2\2\u0188\u0186\3\2\2\2\u0188\u0189\3\2\2\2\u0189[\3\2\2",
+    "\2\u018a\u018b\7\22\2\2\u018b\u018c\7\30\2\2\u018c\u018d\5@!\2\u018d",
+    "]\3\2\2\2\u018e\u0194\7(\2\2\u018f\u0194\7)\2\2\u0190\u0194\7*\2\2\u0191",
+    "\u0194\5\66\34\2\u0192\u0194\5d\63\2\u0193\u018e\3\2\2\2\u0193\u018f",
+    "\3\2\2\2\u0193\u0190\3\2\2\2\u0193\u0191\3\2\2\2\u0193\u0192\3\2\2\2",
+    "\u0194_\3\2\2\2\u0195\u0196\t\b\2\2\u0196a\3\2\2\2\u0197\u0198\7>\2",
+    "\2\u0198\u0199\7\'\2\2\u0199\u019a\t\t\2\2\u019ac\3\2\2\2\u019b\u019d",
+    "\7\37\2\2\u019c\u019e\7D\2\2\u019d\u019c\3\2\2\2\u019d\u019e\3\2\2\2",
+    "\u019ee\3\2\2\2\u019f\u01a1\7 \2\2\u01a0\u01a2\7D\2\2\u01a1\u01a0\3",
+    "\2\2\2\u01a1\u01a2\3\2\2\2\u01a2g\3\2\2\2\65jmps\u0083\u0089\u0093\u009d",
+    "\u00a2\u00a6\u00ab\u00b2\u00bc\u00c1\u00c4\u00c9\u00ce\u00d1\u00d8\u00dc",
+    "\u00e3\u00e6\u00e9\u00f0\u00f4\u00fa\u00ff\u0104\u010b\u011d\u0126\u012b",
+    "\u012f\u0138\u013d\u0140\u0147\u014b\u0151\u0156\u015f\u0164\u0167\u016a",
+    "\u016f\u0178\u0182\u0188\u0193\u019d\u01a1"].join("");
 
 
 var atn = new antlr4.atn.ATNDeserializer().deserialize(serializedATN);
@@ -3470,6 +3471,10 @@ TypeConstraintContext.prototype.ref = function() {
     return this.getTypedRuleContext(RefContext,0);
 };
 
+TypeConstraintContext.prototype.primitive = function() {
+    return this.getTypedRuleContext(PrimitiveContext,0);
+};
+
 TypeConstraintContext.prototype.tbd = function() {
     return this.getTypedRuleContext(TbdContext,0);
 };
@@ -3507,7 +3512,7 @@ SHRDataElementParser.prototype.typeConstraint = function() {
         this.enterOuterAlt(localctx, 1);
         this.state = 305;
         this.count();
-        this.state = 309;
+        this.state = 310;
         switch(this._input.LA(1)) {
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
@@ -3520,8 +3525,28 @@ SHRDataElementParser.prototype.typeConstraint = function() {
             this.state = 307;
             this.ref();
             break;
-        case SHRDataElementParser.KW_TBD:
+        case SHRDataElementParser.KW_BOOLEAN:
+        case SHRDataElementParser.KW_INTEGER:
+        case SHRDataElementParser.KW_STRING:
+        case SHRDataElementParser.KW_DECIMAL:
+        case SHRDataElementParser.KW_URI:
+        case SHRDataElementParser.KW_BASE64_BINARY:
+        case SHRDataElementParser.KW_INSTANT:
+        case SHRDataElementParser.KW_DATE:
+        case SHRDataElementParser.KW_DATE_TIME:
+        case SHRDataElementParser.KW_TIME:
+        case SHRDataElementParser.KW_CODE:
+        case SHRDataElementParser.KW_OID:
+        case SHRDataElementParser.KW_ID:
+        case SHRDataElementParser.KW_MARKDOWN:
+        case SHRDataElementParser.KW_UNSIGNED_INT:
+        case SHRDataElementParser.KW_POSITIVE_INT:
+        case SHRDataElementParser.KW_XHTML:
             this.state = 308;
+            this.primitive();
+            break;
+        case SHRDataElementParser.KW_TBD:
+            this.state = 309;
             this.tbd();
             break;
         default:
@@ -3605,29 +3630,29 @@ SHRDataElementParser.prototype.elementWithConstraint = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 314;
+        this.state = 315;
         var la_ = this._interp.adaptivePredict(this._input,34,this._ctx);
         switch(la_) {
         case 1:
-            this.state = 311;
+            this.state = 312;
             this.simpleOrFQName();
             break;
 
         case 2:
-            this.state = 312;
+            this.state = 313;
             this.elementPath();
             break;
 
         case 3:
-            this.state = 313;
+            this.state = 314;
             this.primitive();
             break;
 
         }
-        this.state = 317;
+        this.state = 318;
         _la = this._input.LA(1);
         if((((_la) & ~0x1f) == 0 && ((1 << _la) & ((1 << SHRDataElementParser.KW_WITH) | (1 << SHRDataElementParser.KW_MUST_BE) | (1 << SHRDataElementParser.KW_SHOULD_BE) | (1 << SHRDataElementParser.KW_COULD_BE) | (1 << SHRDataElementParser.KW_FROM) | (1 << SHRDataElementParser.KW_IS) | (1 << SHRDataElementParser.KW_IS_TYPE) | (1 << SHRDataElementParser.KW_VALUE_IS_TYPE) | (1 << SHRDataElementParser.KW_INCLUDES))) !== 0)) {
-            this.state = 316;
+            this.state = 317;
             this.elementConstraint();
         }
 
@@ -3724,60 +3749,60 @@ SHRDataElementParser.prototype.elementPath = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 319;
+        this.state = 320;
         this.simpleOrFQName();
-        this.state = 339;
+        this.state = 340;
         var la_ = this._interp.adaptivePredict(this._input,39,this._ctx);
         switch(la_) {
         case 1:
-            this.state = 322; 
+            this.state = 323; 
             this._errHandler.sync(this);
             var _alt = 1;
             do {
             	switch (_alt) {
             	case 1:
-            		this.state = 320;
-            		this.match(SHRDataElementParser.DOT);
             		this.state = 321;
+            		this.match(SHRDataElementParser.DOT);
+            		this.state = 322;
             		this.simpleName();
             		break;
             	default:
             		throw new antlr4.error.NoViableAltException(this);
             	}
-            	this.state = 324; 
+            	this.state = 325; 
             	this._errHandler.sync(this);
             	_alt = this._interp.adaptivePredict(this._input,36, this._ctx);
             } while ( _alt!=2 && _alt!=antlr4.atn.ATN.INVALID_ALT_NUMBER );
-            this.state = 328;
+            this.state = 329;
             _la = this._input.LA(1);
             if(_la===SHRDataElementParser.DOT) {
-                this.state = 326;
-                this.match(SHRDataElementParser.DOT);
                 this.state = 327;
+                this.match(SHRDataElementParser.DOT);
+                this.state = 328;
                 this.primitive();
             }
 
             break;
 
         case 2:
-            this.state = 334;
+            this.state = 335;
             this._errHandler.sync(this);
             var _alt = this._interp.adaptivePredict(this._input,38,this._ctx)
             while(_alt!=2 && _alt!=antlr4.atn.ATN.INVALID_ALT_NUMBER) {
                 if(_alt===1) {
-                    this.state = 330;
-                    this.match(SHRDataElementParser.DOT);
                     this.state = 331;
+                    this.match(SHRDataElementParser.DOT);
+                    this.state = 332;
                     this.simpleName(); 
                 }
-                this.state = 336;
+                this.state = 337;
                 this._errHandler.sync(this);
                 _alt = this._interp.adaptivePredict(this._input,38,this._ctx);
             }
 
-            this.state = 337;
-            this.match(SHRDataElementParser.DOT);
             this.state = 338;
+            this.match(SHRDataElementParser.DOT);
+            this.state = 339;
             this.primitive();
             break;
 
@@ -3870,48 +3895,48 @@ SHRDataElementParser.prototype.elementConstraint = function() {
     var localctx = new ElementConstraintContext(this, this._ctx, this.state);
     this.enterRule(localctx, 74, SHRDataElementParser.RULE_elementConstraint);
     try {
-        this.state = 348;
+        this.state = 349;
         var la_ = this._interp.adaptivePredict(this._input,40,this._ctx);
         switch(la_) {
         case 1:
             this.enterOuterAlt(localctx, 1);
-            this.state = 341;
+            this.state = 342;
             this.elementCodeVSConstraint();
             break;
 
         case 2:
             this.enterOuterAlt(localctx, 2);
-            this.state = 342;
+            this.state = 343;
             this.elementCodeValueConstraint();
             break;
 
         case 3:
             this.enterOuterAlt(localctx, 3);
-            this.state = 343;
+            this.state = 344;
             this.elementIncludesCodeValueConstraint();
             break;
 
         case 4:
             this.enterOuterAlt(localctx, 4);
-            this.state = 344;
+            this.state = 345;
             this.elementBooleanConstraint();
             break;
 
         case 5:
             this.enterOuterAlt(localctx, 5);
-            this.state = 345;
+            this.state = 346;
             this.elementTypeConstraint();
             break;
 
         case 6:
             this.enterOuterAlt(localctx, 6);
-            this.state = 346;
+            this.state = 347;
             this.elementIncludesTypeConstraint();
             break;
 
         case 7:
             this.enterOuterAlt(localctx, 7);
-            this.state = 347;
+            this.state = 348;
             this.elementWithUnitsConstraint();
             break;
 
@@ -3989,19 +4014,19 @@ SHRDataElementParser.prototype.legacyWithCode = function() {
     this.enterRule(localctx, 76, SHRDataElementParser.RULE_legacyWithCode);
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 350;
+        this.state = 351;
         this.match(SHRDataElementParser.KW_WITH);
-        this.state = 353;
+        this.state = 354;
         switch(this._input.LA(1)) {
         case SHRDataElementParser.KW_CODE:
-            this.state = 351;
+            this.state = 352;
             this.match(SHRDataElementParser.KW_CODE);
             break;
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
         case SHRDataElementParser.LOWER_WORD:
         case SHRDataElementParser.DOT_SEPARATED_UW:
-            this.state = 352;
+            this.state = 353;
             this.simpleOrFQName();
             break;
         default:
@@ -4089,28 +4114,28 @@ SHRDataElementParser.prototype.elementCodeVSConstraint = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 356;
+        this.state = 357;
         _la = this._input.LA(1);
         if(_la===SHRDataElementParser.KW_WITH) {
-            this.state = 355;
+            this.state = 356;
             this.legacyWithCode();
         }
 
-        this.state = 359;
+        this.state = 360;
         _la = this._input.LA(1);
         if((((_la) & ~0x1f) == 0 && ((1 << _la) & ((1 << SHRDataElementParser.KW_MUST_BE) | (1 << SHRDataElementParser.KW_SHOULD_BE) | (1 << SHRDataElementParser.KW_COULD_BE))) !== 0)) {
-            this.state = 358;
+            this.state = 359;
             this.bindingInfix();
         }
 
-        this.state = 361;
-        this.match(SHRDataElementParser.KW_FROM);
         this.state = 362;
+        this.match(SHRDataElementParser.KW_FROM);
+        this.state = 363;
         this.valueset();
-        this.state = 364;
+        this.state = 365;
         _la = this._input.LA(1);
         if(_la===SHRDataElementParser.KW_IF_COVERED) {
-            this.state = 363;
+            this.state = 364;
             this.match(SHRDataElementParser.KW_IF_COVERED);
         }
 
@@ -4183,9 +4208,9 @@ SHRDataElementParser.prototype.elementCodeValueConstraint = function() {
     this.enterRule(localctx, 80, SHRDataElementParser.RULE_elementCodeValueConstraint);
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 366;
-        this.match(SHRDataElementParser.KW_IS);
         this.state = 367;
+        this.match(SHRDataElementParser.KW_IS);
+        this.state = 368;
         this.codeOrFQCode();
     } catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
@@ -4272,15 +4297,15 @@ SHRDataElementParser.prototype.elementIncludesCodeValueConstraint = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 371; 
+        this.state = 372; 
         this._errHandler.sync(this);
         _la = this._input.LA(1);
         do {
-            this.state = 369;
-            this.match(SHRDataElementParser.KW_INCLUDES);
             this.state = 370;
+            this.match(SHRDataElementParser.KW_INCLUDES);
+            this.state = 371;
             this.codeOrFQCode();
-            this.state = 373; 
+            this.state = 374; 
             this._errHandler.sync(this);
             _la = this._input.LA(1);
         } while(_la===SHRDataElementParser.KW_INCLUDES);
@@ -4358,9 +4383,9 @@ SHRDataElementParser.prototype.elementBooleanConstraint = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 375;
-        this.match(SHRDataElementParser.KW_IS);
         this.state = 376;
+        this.match(SHRDataElementParser.KW_IS);
+        this.state = 377;
         _la = this._input.LA(1);
         if(!(_la===SHRDataElementParser.KW_TRUE || _la===SHRDataElementParser.KW_FALSE)) {
         this._errHandler.recoverInline(this);
@@ -4414,6 +4439,10 @@ ElementTypeConstraintContext.prototype.ref = function() {
     return this.getTypedRuleContext(RefContext,0);
 };
 
+ElementTypeConstraintContext.prototype.primitive = function() {
+    return this.getTypedRuleContext(PrimitiveContext,0);
+};
+
 ElementTypeConstraintContext.prototype.tbd = function() {
     return this.getTypedRuleContext(TbdContext,0);
 };
@@ -4450,7 +4479,7 @@ SHRDataElementParser.prototype.elementTypeConstraint = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 378;
+        this.state = 379;
         _la = this._input.LA(1);
         if(!(_la===SHRDataElementParser.KW_IS_TYPE || _la===SHRDataElementParser.KW_VALUE_IS_TYPE)) {
         this._errHandler.recoverInline(this);
@@ -4458,21 +4487,41 @@ SHRDataElementParser.prototype.elementTypeConstraint = function() {
         else {
             this.consume();
         }
-        this.state = 382;
+        this.state = 384;
         switch(this._input.LA(1)) {
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
         case SHRDataElementParser.LOWER_WORD:
         case SHRDataElementParser.DOT_SEPARATED_UW:
-            this.state = 379;
+            this.state = 380;
             this.simpleOrFQName();
             break;
         case SHRDataElementParser.KW_REF:
-            this.state = 380;
+            this.state = 381;
             this.ref();
             break;
+        case SHRDataElementParser.KW_BOOLEAN:
+        case SHRDataElementParser.KW_INTEGER:
+        case SHRDataElementParser.KW_STRING:
+        case SHRDataElementParser.KW_DECIMAL:
+        case SHRDataElementParser.KW_URI:
+        case SHRDataElementParser.KW_BASE64_BINARY:
+        case SHRDataElementParser.KW_INSTANT:
+        case SHRDataElementParser.KW_DATE:
+        case SHRDataElementParser.KW_DATE_TIME:
+        case SHRDataElementParser.KW_TIME:
+        case SHRDataElementParser.KW_CODE:
+        case SHRDataElementParser.KW_OID:
+        case SHRDataElementParser.KW_ID:
+        case SHRDataElementParser.KW_MARKDOWN:
+        case SHRDataElementParser.KW_UNSIGNED_INT:
+        case SHRDataElementParser.KW_POSITIVE_INT:
+        case SHRDataElementParser.KW_XHTML:
+            this.state = 382;
+            this.primitive();
+            break;
         case SHRDataElementParser.KW_TBD:
-            this.state = 381;
+            this.state = 383;
             this.tbd();
             break;
         default:
@@ -4563,15 +4612,15 @@ SHRDataElementParser.prototype.elementIncludesTypeConstraint = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 386; 
+        this.state = 388; 
         this._errHandler.sync(this);
         _la = this._input.LA(1);
         do {
-            this.state = 384;
+            this.state = 386;
             this.match(SHRDataElementParser.KW_INCLUDES);
-            this.state = 385;
+            this.state = 387;
             this.typeConstraint();
-            this.state = 388; 
+            this.state = 390; 
             this._errHandler.sync(this);
             _la = this._input.LA(1);
         } while(_la===SHRDataElementParser.KW_INCLUDES);
@@ -4648,11 +4697,11 @@ SHRDataElementParser.prototype.elementWithUnitsConstraint = function() {
     this.enterRule(localctx, 90, SHRDataElementParser.RULE_elementWithUnitsConstraint);
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 390;
-        this.match(SHRDataElementParser.KW_WITH);
-        this.state = 391;
-        this.match(SHRDataElementParser.KW_UNITS);
         this.state = 392;
+        this.match(SHRDataElementParser.KW_WITH);
+        this.state = 393;
+        this.match(SHRDataElementParser.KW_UNITS);
+        this.state = 394;
         this.fullyQualifiedCode();
     } catch (re) {
     	if(re instanceof antlr4.error.RecognitionException) {
@@ -4734,33 +4783,33 @@ SHRDataElementParser.prototype.valueset = function() {
     var localctx = new ValuesetContext(this, this._ctx, this.state);
     this.enterRule(localctx, 92, SHRDataElementParser.RULE_valueset);
     try {
-        this.state = 399;
+        this.state = 401;
         switch(this._input.LA(1)) {
         case SHRDataElementParser.URL:
             this.enterOuterAlt(localctx, 1);
-            this.state = 394;
+            this.state = 396;
             this.match(SHRDataElementParser.URL);
             break;
         case SHRDataElementParser.PATH_URL:
             this.enterOuterAlt(localctx, 2);
-            this.state = 395;
+            this.state = 397;
             this.match(SHRDataElementParser.PATH_URL);
             break;
         case SHRDataElementParser.URN_OID:
             this.enterOuterAlt(localctx, 3);
-            this.state = 396;
+            this.state = 398;
             this.match(SHRDataElementParser.URN_OID);
             break;
         case SHRDataElementParser.ALL_CAPS:
         case SHRDataElementParser.UPPER_WORD:
         case SHRDataElementParser.LOWER_WORD:
             this.enterOuterAlt(localctx, 4);
-            this.state = 397;
+            this.state = 399;
             this.simpleName();
             break;
         case SHRDataElementParser.KW_TBD:
             this.enterOuterAlt(localctx, 5);
-            this.state = 398;
+            this.state = 400;
             this.tbd();
             break;
         default:
@@ -4896,7 +4945,7 @@ SHRDataElementParser.prototype.primitive = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 401;
+        this.state = 403;
         _la = this._input.LA(1);
         if(!(((((_la - 43)) & ~0x1f) == 0 && ((1 << (_la - 43)) & ((1 << (SHRDataElementParser.KW_BOOLEAN - 43)) | (1 << (SHRDataElementParser.KW_INTEGER - 43)) | (1 << (SHRDataElementParser.KW_STRING - 43)) | (1 << (SHRDataElementParser.KW_DECIMAL - 43)) | (1 << (SHRDataElementParser.KW_URI - 43)) | (1 << (SHRDataElementParser.KW_BASE64_BINARY - 43)) | (1 << (SHRDataElementParser.KW_INSTANT - 43)) | (1 << (SHRDataElementParser.KW_DATE - 43)) | (1 << (SHRDataElementParser.KW_DATE_TIME - 43)) | (1 << (SHRDataElementParser.KW_TIME - 43)) | (1 << (SHRDataElementParser.KW_CODE - 43)) | (1 << (SHRDataElementParser.KW_OID - 43)) | (1 << (SHRDataElementParser.KW_ID - 43)) | (1 << (SHRDataElementParser.KW_MARKDOWN - 43)) | (1 << (SHRDataElementParser.KW_UNSIGNED_INT - 43)) | (1 << (SHRDataElementParser.KW_POSITIVE_INT - 43)) | (1 << (SHRDataElementParser.KW_XHTML - 43)))) !== 0))) {
         this._errHandler.recoverInline(this);
@@ -4986,11 +5035,11 @@ SHRDataElementParser.prototype.count = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 403;
-        this.match(SHRDataElementParser.WHOLE_NUMBER);
-        this.state = 404;
-        this.match(SHRDataElementParser.RANGE);
         this.state = 405;
+        this.match(SHRDataElementParser.WHOLE_NUMBER);
+        this.state = 406;
+        this.match(SHRDataElementParser.RANGE);
+        this.state = 407;
         _la = this._input.LA(1);
         if(!(_la===SHRDataElementParser.STAR || _la===SHRDataElementParser.WHOLE_NUMBER)) {
         this._errHandler.recoverInline(this);
@@ -5068,12 +5117,12 @@ SHRDataElementParser.prototype.tbd = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 407;
-        this.match(SHRDataElementParser.KW_TBD);
         this.state = 409;
+        this.match(SHRDataElementParser.KW_TBD);
+        this.state = 411;
         _la = this._input.LA(1);
         if(_la===SHRDataElementParser.STRING) {
-            this.state = 408;
+            this.state = 410;
             this.match(SHRDataElementParser.STRING);
         }
 
@@ -5147,12 +5196,12 @@ SHRDataElementParser.prototype.tbdCode = function() {
     var _la = 0; // Token type
     try {
         this.enterOuterAlt(localctx, 1);
-        this.state = 411;
-        this.match(SHRDataElementParser.KW_TBD_CODE);
         this.state = 413;
+        this.match(SHRDataElementParser.KW_TBD_CODE);
+        this.state = 415;
         _la = this._input.LA(1);
         if(_la===SHRDataElementParser.STRING) {
-            this.state = 412;
+            this.state = 414;
             this.match(SHRDataElementParser.STRING);
         }
 

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -5,8 +5,8 @@ const {SHRDataElementParser} = require('./parsers/SHRDataElementParser');
 const {SHRDataElementParserVisitor} = require('./parsers/SHRDataElementParserVisitor');
 const {Version} = require('shr-models');
 
-const VERSION = new Version(4, 1, 1);
-const GRAMMAR_VERSION = new Version(5, 0, 0);
+const VERSION = new Version(5, 2, 3);
+const GRAMMAR_VERSION = new Version(5, 0, 1);
 
 var rootLogger = bunyan.createLogger({name: 'shr-text-import'});
 var logger = rootLogger;
@@ -26,12 +26,12 @@ class Preprocessor extends SHRDataElementParserVisitor {
   get data() { return this._data; }
 
   preprocessConfig(defaultsFile, file) {
-    
+
     var defaults = JSON.parse(defaultsFile);
     var configFile = {};
 
     if (file != null) {
-      try { configFile = JSON.parse(new FileStream(file)); } 
+      try { configFile = JSON.parse(new FileStream(file)); }
       catch (e) {
         logger.error('Invalid config file. Should be valid JSON dictionary. ERROR_CODE:11006');
         return defaults;
@@ -47,8 +47,8 @@ class Preprocessor extends SHRDataElementParserVisitor {
         if (key === 'fhirURL' && configFile['projectURL'] != null) { //special logic
           configFile['fhirURL'] = `${configFile['projectURL']}/fhir`;
           continue;
-        } 
-        
+        }
+
         configFile[key] = defaults[key];
         logger.warn('Configuration file missing key: %s, using default key: %s instead. ERROR_CODE:01002', key, defaults[key]);
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-text-import",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Imports Standard Health Record (SHR) elements from their custom grammar to the SHR models",
   "author": "",
   "license": "Apache-2.0",

--- a/test/fixtures/dataElement/ChoiceTypeConstraints.txt
+++ b/test/fixtures/dataElement/ChoiceTypeConstraints.txt
@@ -1,0 +1,19 @@
+Grammar:    DataElement 5.0
+Namespace:  shr.test
+
+EntryElement: ChoiceOfDatishThings
+Value:        date or dateTime or StringishDateTime
+
+EntryElement: ThingWithChoiceField
+1..1          ChoiceOfDatishThings
+
+EntryElement: PrimitiveTypeConstraintOnField
+Based on:     ThingWithChoiceField
+              ChoiceOfDatishThings value is type dateTime
+
+EntryElement: NonPrimitiveTypeConstraintOnField
+Based on:     ThingWithChoiceField
+              ChoiceOfDatishThings value is type StringishDateTime
+
+Element:      StringishDateTime
+Value:        string

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -653,6 +653,46 @@ describe('#importFromFilePath()', () => {
     expectIdentifier(group.fields[0].constraints[0].isA, 'shr.test', 'Simple2');
   });
 
+  // Type constraints on choices
+
+  it('should correctly import an entry with a value type constraint (to primitive) on a choice field', () => {
+    const specifications = importFixture('ChoiceTypeConstraints');
+    const primType = expectAndGetEntry(specifications, 'shr.test', 'PrimitiveTypeConstraintOnField');
+    expect(primType.basedOn).to.have.length(1);
+    expectIdentifier(primType.basedOn[0], 'shr.test', 'ThingWithChoiceField');
+    expect(primType.concepts).to.be.empty;
+    expect(primType.description).to.be.undefined;
+    expect(primType.value).to.be.undefined;
+    expect(primType.fields).to.have.length(1);
+    expectField(primType, 0, 'shr.test', 'ChoiceOfDatishThings');
+    expect(primType.fields[0].constraints).to.have.length(1);
+    expect(primType.fields[0].constraints[0]).to.be.instanceof(TypeConstraint);
+    expect(primType.fields[0].constraints[0].path).to.be.empty;
+    expect(primType.fields[0].constraints[0].onValue).to.be.true;
+    expectPrimitiveIdentifier(primType.fields[0].constraints[0].isA, 'dateTime');
+  });
+
+  it('should correctly import an entry with a value type constraint (to non-primitive) on a choice field', () => {
+    const specifications = importFixture('ChoiceTypeConstraints');
+    const primType = expectAndGetEntry(specifications, 'shr.test', 'NonPrimitiveTypeConstraintOnField');
+    expect(primType.basedOn).to.have.length(1);
+    expectIdentifier(primType.basedOn[0], 'shr.test', 'ThingWithChoiceField');
+    expect(primType.concepts).to.be.empty;
+    expect(primType.description).to.be.undefined;
+    expect(primType.value).to.be.undefined;
+    expect(primType.fields).to.have.length(1);
+    expectField(primType, 0, 'shr.test', 'ChoiceOfDatishThings');
+    expect(primType.fields[0].constraints).to.have.length(1);
+    expect(primType.fields[0].constraints[0]).to.be.instanceof(TypeConstraint);
+    expect(primType.fields[0].constraints[0].path).to.be.empty;
+    expect(primType.fields[0].constraints[0].onValue).to.be.true;
+    expectIdentifier(primType.fields[0].constraints[0].isA, 'shr.test', 'StringishDateTime');
+  });
+
+
+
+
+
   it('should correctly import an entry with a card constraint on the value\'s child', () => {
     const specifications = importFixture('CardConstraints');
     const entry = expectAndGetEntry(specifications, 'shr.test', 'CardConstraintOnValueChild');


### PR DESCRIPTION
The "value is type" type constraint can also be used to constrain a choice to a subset.  In this case, the type you are constraining could be a primitive.  Prior to this fix, the parser choked if trying to constrain to a primitive.

Fixes #27.