### PR TITLE
Added action tag to ValueSet and Codesystem URLs

### DIFF
--- a/lib/valueSetListener.js
+++ b/lib/valueSetListener.js
@@ -109,7 +109,7 @@ class ValueSetImporter extends SHRValueSetParserListener {
       return;
     }
     const identifier = new Identifier(this._currentNs, h.simpleName().getText());
-    const url = `${this._currentPath}${identifier.name}`;
+    const url = `${this._currentPath}#${identifier.name}`;
     this._currentDef = new ValueSet(identifier, url);
     this._currentDef.grammarVersion = this._currentGrammarVersion;
   }
@@ -234,7 +234,7 @@ class ValueSetImporter extends SHRValueSetParserListener {
       // To eliminate confusion, if the name ends with VS, replace it with CS
       const vsID = this._currentDef.identifier;
       const identifier = new Identifier(vsID.namespace, vsID.name.replace(/VS$/, 'CS'));
-      const csURL = `${csPath}${identifier.name}`;
+      const csURL = `${csPath}#${identifier.name}`;
       this._currentCodeSystemDef = new CodeSystem(identifier, csURL);
       if (typeof this._currentDef.description !== 'undefined') {
         this._currentCodeSystemDef.description = this._currentDef.description;


### PR DESCRIPTION
This resolves an error in the urls where shr.org `#` anchor tags were missing from urls. Necessary for valid reference links in the javadoc.

Previously:
`http://standardhealthrecord.org/shr/core/vs/PerformanceGradingScaleVS`

Fixed to:
`http://standardhealthrecord.org/shr/core/vs/#PerformanceGradingScaleVS`

(this breaks links outputted in files by `shr-json-export`, as they use similar logic to fix the links, resulting in duplicate `#`s. This repo may soon be deprecated, but I'll make a separate PR for that fix anyway after I've finished this round of bug fix and CIMCORE PRs). 