### PR TITLE
Logical models

### DIFF
--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -67,7 +67,7 @@ class DataElementImporter extends SHRDataElementParserListener {
       this._specs.namespaces.add(nsDef);
     }
     if (ctx.descriptionProp() && typeof nsDef.description === 'undefined') {
-      nsDef.description = stripDelimitersFromToken(ctx.descriptionProp().STRING());
+      nsDef.description = trimLines(stripDelimitersFromToken(ctx.descriptionProp().STRING()));
     }
 
     // Process the version
@@ -138,7 +138,7 @@ class DataElementImporter extends SHRDataElementParserListener {
       // Skip this -- already handled elsewhere
       return;
     }
-    this._currentDef.description = stripDelimitersFromToken(ctx.STRING());
+    this._currentDef.description = trimLines(stripDelimitersFromToken(ctx.STRING()));
   }
 
   enterConcepts(ctx) {
@@ -544,6 +544,15 @@ function stripDelimitersFromToken(tkn) {
   const str = tkn.getText();
   // TODO: Also fix escaped double-quotes, but right now, the parser seems to be screwing those up.
   return str.substr(1,str.length -2);
+}
+
+function trimLines(str) {
+  // The way CIMPL authors often indent their definitions, multi-line descriptions may have indented white space on
+  // each new line.  We really don't want that, so we need to trim every line.
+  if (typeof str === 'string') {
+    return str.split('\n').map(s => s.trim()).join('\n');
+  }
+  return str;
 }
 
 module.exports = {DataElementImporter, setLogger};

--- a/lib/valueSetListener.js
+++ b/lib/valueSetListener.js
@@ -63,8 +63,12 @@ class ValueSetImporter extends SHRValueSetParserListener {
     // Process the namespace
     this._currentNs = ctx.docHeader().namespace().getText();
 
-    // Create the default path based on the namespace
-    this._currentPath = `${this._config.projectURL}/${this._currentNs.replace('.', '/')}/vs/`;
+    // Create the default path.  If the project URL is the same as FHIR url, use FHIR-friendly path
+    if (this._config.projectURL === this._config.fhirURL) {
+      this._currentPath = `${this._config.projectURL}/ValueSet/${this._currentNs.replace(/\./g, '-')}-`;
+    } else {
+      this._currentPath = `${this._config.projectURL}/${this._currentNs.replace('.', '/')}/vs/`;
+    }
 
     // Process the version
     const version = ctx.docHeader().version();
@@ -228,6 +232,8 @@ class ValueSetImporter extends SHRValueSetParserListener {
       let csPath;
       if (this._currentPath.indexOf('/vs/') >= 0) {
         csPath = this._currentPath.replace('/vs/', '/cs/');
+      } else if (this._currentPath.indexOf('/ValueSet/') >= 0) {
+        csPath = this._currentPath.replace('/ValueSet/', '/CodeSystem/');
       } else {
         csPath = `${this._currentPath}cs/`;
       }

--- a/lib/valueSetListener.js
+++ b/lib/valueSetListener.js
@@ -119,7 +119,7 @@ class ValueSetImporter extends SHRValueSetParserListener {
   }
 
   enterDescriptionProp(ctx) {
-    this._currentDef.description = stripDelimitersFromToken(ctx.STRING());
+    this._currentDef.description = trimLines(stripDelimitersFromToken(ctx.STRING()));
   }
 
   enterConcepts(ctx) {
@@ -274,6 +274,15 @@ function stripDelimitersFromToken(tkn) {
   const str = tkn.getText();
   // TODO: Also fix escaped double-quotes, but right now, the parser seems to be screwing those up.
   return str.substr(1,str.length -2);
+}
+
+function trimLines(str) {
+  // The way CIMPL authors often indent their definitions, multi-line descriptions may have indented white space on
+  // each new line.  We really don't want that, so we need to trim every line.
+  if (typeof str === 'string') {
+    return str.split('\n').map(s => s.trim()).join('\n');
+  }
+  return str;
 }
 
 module.exports = {ValueSetImporter, setLogger};

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-models": "^5.4.0",
+    "shr-models": "^5.5.0",
     "shr-test-helpers": "^5.1.3"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.4.0"
+    "shr-models": "^5.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-text-import",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Imports Standard Health Record (SHR) elements from their custom grammar to the SHR models",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,9 +885,9 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.4.0.tgz#6fc2542dbdb900a7e0a7d172962ce540deda190a"
+shr-models@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.0.tgz#41c163bfb22aa39678c2bafebccccb50a8574a3a"
 
 shr-test-helpers@^5.1.3:
   version "5.1.3"


### PR DESCRIPTION
This PR mainly adds a change to trim every line of multi-line comments.  This was necessary for the IG output to look correct.  In addition, it adds special logic when creating the VS/CS canonical URLs to make them match the FHIR IG canonical URL when appropriate.

This code represents the exact code used to generate the HL7 US Breast Cancer May 2018 ballot.  Note that it should be tested against standardhealth/shr_spec#may-2018-ballot-topic-context.  There are known issues testing against standardhealth/shr_spec#master, but we need to cut a release that matches exactly the toolchain used for the ballot.

This is one of seven PRs related to the logical models and HL7 ballot:
- shr-models
- shr-text-import
- shr-expand
- shr-fhir-export
- shr-json-schema-export
- shr-test-helpers
- shr-cli