### PR TITLE
Config updates

### DIFF
--- a/lib/config-template/default_config.json
+++ b/lib/config-template/default_config.json
@@ -3,7 +3,9 @@
     "projectShorthand": "EXAMPLE",
     "projectURL": "http://example.com",
     "fhirURL": "http://example.com/fhir",
-    "igIndexContent": "exampleIndexContent.html",
+    "implementationGuide": {
+      "indexContent": "exampleIndexContent.html"
+    },
     "publisher": "Example Publisher",
     "contact": [
         {

--- a/lib/import.js
+++ b/lib/import.js
@@ -38,7 +38,7 @@ function importFromFilePath(filePath, configuration=[], specifications = new Spe
   return specifications;
 }
 
-function importConfigFromFilePath(filePath) {
+function importConfigFromFilePath(filePath, configName) {
   const filesByType = processPath(filePath);
   const preprocessor = new Preprocessor();
 
@@ -50,7 +50,7 @@ function importConfigFromFilePath(filePath) {
     configuration = preprocessor.preprocessConfig(defaultConfigFile, filesByType.config[0]);
   } else {
     configuration = preprocessor.preprocessConfig(defaultConfigFile);
-    fs.writeFileSync(filePath + '/config.json', defaultConfigFile, 'utf8');
+    fs.writeFileSync(filePath + '/' + configName, defaultConfigFile, 'utf8');
   }
 
   return configuration;

--- a/lib/import.js
+++ b/lib/import.js
@@ -45,12 +45,21 @@ function importConfigFromFilePath(filePath, configName) {
   let defaultConfigPath = path.join(__dirname, 'config-template', '/default_config.json');
   let defaultConfigFile = fs.readFileSync(defaultConfigPath, 'utf8');
 
-  let configuration;
+  let configuration; // variable to store configuration data
+  let configFile; // variable to store config file to be used
+
   if (filesByType.config.length > 0) {
-    configuration = preprocessor.preprocessConfig(defaultConfigFile, filesByType.config[0]);
+    configFile = filesByType.config.find((file) => {
+      return (file === filePath + configName);
+    }) || filesByType.config[0];
+  }
+
+  if (configFile) {
+    logger.info('Using config file %s', configFile);
+    configuration = preprocessor.preprocessConfig(defaultConfigFile, configFile);
   } else {
     configuration = preprocessor.preprocessConfig(defaultConfigFile);
-    fs.writeFileSync(filePath + '/' + configName, defaultConfigFile, 'utf8');
+    fs.writeFileSync(filePath + '/config.json', defaultConfigFile, 'utf8');
   }
 
   return configuration;

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -56,19 +56,26 @@ class Preprocessor extends SHRDataElementParserVisitor {
           if (configFile['igIndexContent'] != null) {
             logger.warn(`Configuration file 'igIndexContent' field will be deprecated. Use 'implementationGuide.indexContent' instead.`);
             igObject.indexContent = configFile['igIndexContent'];
+          } else { // since we use continue at end of old ig field conditional, we need to handle the case of implementationGuide.indexContent separately
+            logger.warn('Configuration file missing key: implementationGuide.indexContent, using default key: %s instead. ERROR_CODE:01002', defaults['implementationGuide']['indexContent']);
+            igObject.indexContent = defaults['implementationGuide']['indexContent'];
           }
+
           if (configFile['igLogicalModels'] != null) {
             logger.warn(`Configuration file 'igLogicalModels' field will be deprecated. Use 'implementationGuide.includeLogicalModels' instead.`);
             igObject.includeLogicalModels = configFile['igLogicalModels'];
           }
+
           if (configFile['igModelDoc'] != null) {
             logger.warn(`Configuration file 'igModelDoc' field will be deprecated. Use 'implementationGuide.includeModelDoc' instead.`);
             igObject.includeModelDoc = configFile['igModelDoc'];
           }
+
           if (configFile['igPrimarySelectionStrategy'] != null) {
             logger.warn(`Configuration file 'igPrimarySelectionStrategy' field will be deprecated. Use 'implementationGuide.primarySelectionStrategy' instead.`);
             igObject.primarySelectionStrategy = configFile['igPrimarySelectionStrategy'];
           }
+
           configFile['implementationGuide'] = igObject;
           continue;
         }

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -49,6 +49,30 @@ class Preprocessor extends SHRDataElementParserVisitor {
           continue;
         }
 
+        //handle old ig fields
+        // TODO remove this handling once we fully deprecate the old ig fields
+        if (key === 'implementationGuide') {
+          let igObject = {};
+          if (configFile['igIndexContent'] != null) {
+            logger.warn(`Configuration file 'igIndexContent' field will be deprecated. Use 'implementationGuide.indexContent' instead.`);
+            igObject.indexContent = configFile['igIndexContent'];
+          }
+          if (configFile['igLogicalModels'] != null) {
+            logger.warn(`Configuration file 'igLogicalModels' field will be deprecated. Use 'implementationGuide.includeLogicalModels' instead.`);
+            igObject.includeLogicalModels = configFile['igLogicalModels'];
+          }
+          if (configFile['igModelDoc'] != null) {
+            logger.warn(`Configuration file 'igModelDoc' field will be deprecated. Use 'implementationGuide.includeModelDoc' instead.`);
+            igObject.includeModelDoc = configFile['igModelDoc'];
+          }
+          if (configFile['igPrimarySelectionStrategy'] != null) {
+            logger.warn(`Configuration file 'igPrimarySelectionStrategy' field will be deprecated. Use 'implementationGuide.primarySelectionStrategy' instead.`);
+            igObject.primarySelectionStrategy = configFile['igPrimarySelectionStrategy'];
+          }
+          configFile['implementationGuide'] = igObject;
+          continue;
+        }
+
         configFile[key] = defaults[key];
         logger.warn('Configuration file missing key: %s, using default key: %s instead. ERROR_CODE:01002', key, defaults[key]);
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-text-import",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "Imports Standard Health Record (SHR) elements from their custom grammar to the SHR models",
   "author": "",
   "license": "Apache-2.0",

--- a/test/fixtures/config/basicconfig.txt
+++ b/test/fixtures/config/basicconfig.txt
@@ -3,7 +3,9 @@
     "projectShorthand":"TEST",
     "projectURL":"http://test.org",
     "fhirURL": "http://test.org/fhir",
-    "igIndexContent": "basicindexcontent.html",
+    "implementationGuide": {
+      "indexContent": "basicindexcontent.html"
+    },
     "publisher":"Test Publisher",
     "contact":[{
         "telecom":[{

--- a/test/fixtures/config/emptyfolder/config.json
+++ b/test/fixtures/config/emptyfolder/config.json
@@ -3,7 +3,9 @@
     "projectShorthand": "EXAMPLE",
     "projectURL": "http://example.com",
     "fhirURL": "http://example.com/fhir",
-    "igIndexContent": "exampleIndexContent.html",
+    "implementationGuide": {
+      "indexContent": "exampleIndexContent.html"
+    },
     "publisher": "Example Publisher",
     "contact": [
         {

--- a/test/fixtures/config/incompletefhirconfig.txt
+++ b/test/fixtures/config/incompletefhirconfig.txt
@@ -2,7 +2,9 @@
     "projectName":"Test Project",
     "projectShorthand":"TEST",
     "projectURL":"http://test.org",
-    "igIndexContent": "basicindexcontent.html",
+    "implementationGuide": {
+      "indexContent": "basicindexcontent.html"
+    },
     "publisher":"Test Publisher",
     "contact":[{
         "telecom":[{

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -920,12 +920,12 @@ describe('#importConfigFromFilePath', () => {
 
   it('should correctly import a basic configuration', () => {
     const configuration = importConfiguration('basicconfig');
-    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','implementationGuide');
     expect(configuration.projectName).to.eql('Test Project');
     expect(configuration.projectShorthand).to.eql('TEST');
     expect(configuration.projectURL).to.eql('http://test.org');
     expect(configuration.fhirURL).to.eql('http://test.org/fhir');
-    expect(configuration.igIndexContent).to.eql('basicindexcontent.html');
+    expect(configuration.implementationGuide.indexContent).to.eql('basicindexcontent.html');
     expect(configuration.publisher).to.eql('Test Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
@@ -938,12 +938,12 @@ describe('#importConfigFromFilePath', () => {
 
   it('should correctly generate missing fhir url from project url when fhir url is missing', () => {
     const configuration = importConfiguration('incompletefhirconfig');
-    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','implementationGuide');
     expect(configuration.projectName).to.eql('Test Project');
     expect(configuration.projectShorthand).to.eql('TEST');
     expect(configuration.projectURL).to.eql('http://test.org');
     expect(configuration.fhirURL).to.eql('http://test.org/fhir');
-    expect(configuration.igIndexContent).to.eql('basicindexcontent.html');
+    expect(configuration.implementationGuide.indexContent).to.eql('basicindexcontent.html');
     expect(configuration.publisher).to.eql('Test Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
@@ -957,12 +957,12 @@ describe('#importConfigFromFilePath', () => {
 
   it('should correctly use full default configuration when config is empty', () => {
     const configuration = importConfiguration('emptyconfig');
-    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','implementationGuide');
     expect(configuration.projectName).to.eql('Example Project');
     expect(configuration.projectShorthand).to.eql('EXAMPLE');
     expect(configuration.projectURL).to.eql('http://example.com');
     expect(configuration.fhirURL).to.eql('http://example.com/fhir');
-    expect(configuration.igIndexContent).to.eql('exampleIndexContent.html');
+    expect(configuration.implementationGuide.indexContent).to.eql('exampleIndexContent.html');
     expect(configuration.publisher).to.eql('Example Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
@@ -975,12 +975,12 @@ describe('#importConfigFromFilePath', () => {
 
   it('should correctly import an incomplete configuration with partial default data', () => {
     const configuration = importConfiguration('incompleteconfig');
-    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','implementationGuide');
     expect(configuration.projectName).to.eql('Test Project');
     expect(configuration.projectShorthand).to.eql('EXAMPLE');
     expect(configuration.projectURL).to.eql('http://example.com');
     expect(configuration.fhirURL).to.eql('http://example.com/fhir');
-    expect(configuration.igIndexContent).to.eql('exampleIndexContent.html');
+    expect(configuration.implementationGuide.indexContent).to.eql('exampleIndexContent.html');
     expect(configuration.publisher).to.eql('Example Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
@@ -995,12 +995,12 @@ describe('#importConfigFromFilePath', () => {
   it('should correctly throw error then use full default configuration when file is not valid JSON', () => {
     const configuration = importConfiguration('invalidblankconfig', 1);
     expect(err.errors()[0].msg).to.contain('Invalid config file');
-    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','implementationGuide');
     expect(configuration.projectName).to.eql('Example Project');
     expect(configuration.projectShorthand).to.eql('EXAMPLE');
     expect(configuration.projectURL).to.eql('http://example.com');
     expect(configuration.fhirURL).to.eql('http://example.com/fhir');
-    expect(configuration.igIndexContent).to.eql('exampleIndexContent.html');
+    expect(configuration.implementationGuide.indexContent).to.eql('exampleIndexContent.html');
     expect(configuration.publisher).to.eql('Example Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({
@@ -1013,12 +1013,12 @@ describe('#importConfigFromFilePath', () => {
 
   it('should correctly throw error then use full default configuration when no file exists', () => {
     const configuration = importConfigurationFolder('emptyfolder');
-    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','igIndexContent');
+    expect(configuration).to.have.all.keys('projectName','projectShorthand','projectURL','publisher','contact','fhirURL','implementationGuide');
     expect(configuration.projectName).to.eql('Example Project');
     expect(configuration.projectShorthand).to.eql('EXAMPLE');
     expect(configuration.projectURL).to.eql('http://example.com');
     expect(configuration.fhirURL).to.eql('http://example.com/fhir');
-    expect(configuration.igIndexContent).to.eql('exampleIndexContent.html');
+    expect(configuration.implementationGuide.indexContent).to.eql('exampleIndexContent.html');
     expect(configuration.publisher).to.eql('Example Publisher');
     expect(configuration.contact).to.be.of.length(1);
     expect(configuration.contact[0]).to.eql({


### PR DESCRIPTION
PR 3 of 5 for `config-updates`. The remaining are in `shr_spec`, `shr-cli`, `shr-fhir-export`, `shr-es6-export`.

These PRs implement:
-A refactored configuration file
-A split between primary selection strategy and filter strategy
-The ability to select a configuration file from the command line
-Added documentation in `shr-cli` for configuration file usage