### PR TITLE
moved cimcore tests to its own test suite.

### DIFF
--- a/test/import-cimcore-test.js
+++ b/test/import-cimcore-test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const {expect} = require('chai');
+const {setLogger} = require('../index');
+
+// ** mlt: uncomment the next 2 lines once we have actual test samples to verify.
+// const {id, pid, expectAndGetElement, expectAndGetEntry, expectValue, expectPrimitiveValue, expectChoiceValue, expectCardOne, expectChoiceOption, expectField, expectConcept, expectIdentifier, expectPrimitiveIdentifier, expectNoConstraints, importFixture, importFixtureFolder } = require('../test/import-helper');
+// const {Version, IncompleteValue, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, CardConstraint, TBD, REQUIRED, EXTENSIBLE, PREFERRED, EXAMPLE} = require('shr-models');
+const err = require('shr-test-helpers/errors');
+
+// mlt: All of the cimcore test samples need updating to CIMPL6 grammar
+
+/*
+describe('#importCimcoreFromFilePath', () => {
+    it('Cimcore1: should be able to correctly import specifications instance and then export to identical cimcore', () => {
+      const [importedConfigSpecifications, importedSpecifications] = importCimcoreFolder();
+  
+      //This is the cimcore produced from importedSpecs. Used for verifying fidelity
+      const cimcoreSpecifications = convertSpecsToCimcore(importedConfigSpecifications, importedSpecifications);
+  
+      //All CIMCORE files are verified through string comparison. This is perhaps not ideal as they can still be
+      //valid files if the same elemenets are outputted in a different order. However, this should not be a problem
+      //for now, as the process that produced the original fixtures and the process that produces the unit test are
+      //identical in their ordering of outputs. This change should be a considered update in the future.
+  
+      const origProjectJSON = importCimcoreProjectFile();
+      expect(JSON.stringify(cimcoreSpecifications.projectInfo, null, 2)).to.eql(origProjectJSON);
+  
+      //meta namespace files
+      for (const ns in cimcoreSpecifications.namespaces) { //namespace files
+        const origNsJSON = importCimcoreNSFile(ns);
+        expect(JSON.stringify(cimcoreSpecifications.namespaces[ns], null, 2)).to.eql(origNsJSON);
+      }
+  
+      //data elements
+      for (const de of cimcoreSpecifications.dataElements) { //namespace files
+        const origDeJSON = importCimcoreDEFile(de.namespace, de.name);
+        expect(JSON.stringify(de, null, 2)).to.eql(origDeJSON);
+      }
+  
+      //valuesets
+      for (const vs of cimcoreSpecifications.valueSets) {
+        const origVsJSON = importCimcoreVSFile(vs.namespace, vs.name);
+        expect(JSON.stringify(vs, null, 2)).to.eql(origVsJSON);
+      }
+  
+      //mappings
+      for (const mapping of [...cimcoreSpecifications.mappings]) {
+        const origMapJSON = importCimcoreMapFile(mapping.namespace, mapping.name);
+        expect(JSON.stringify(mapping, null, 2)).to.eql(origMapJSON);
+      }
+  
+    });
+  });
+  */

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -764,50 +764,8 @@ describe('#importDataElement', () => {
 // mlt: modularized config tests. Now located in config-import-test.js
 
 
-/* MK - cutting out CIMCORE tests because the examples are out of date, in Grammar 5. If we revive this, it should live in a separate file (e.g., cimcore-test.js).
-
-
-describe('#importCimcoreFromFilePath', () => {
-  it('Cimcore1: should be able to correctly import specifications instance and then export to identical cimcore', () => {
-    const [importedConfigSpecifications, importedSpecifications] = importCimcoreFolder();
-
-    //This is the cimcore produced from importedSpecs. Used for verifying fidelity
-    const cimcoreSpecifications = convertSpecsToCimcore(importedConfigSpecifications, importedSpecifications);
-
-    //All CIMCORE files are verified through string comparison. This is perhaps not ideal as they can still be
-    //valid files if the same elemenets are outputted in a different order. However, this should not be a problem
-    //for now, as the process that produced the original fixtures and the process that produces the unit test are
-    //identical in their ordering of outputs. This change should be a considered update in the future.
-
-    const origProjectJSON = importCimcoreProjectFile();
-    expect(JSON.stringify(cimcoreSpecifications.projectInfo, null, 2)).to.eql(origProjectJSON);
-
-    //meta namespace files
-    for (const ns in cimcoreSpecifications.namespaces) { //namespace files
-      const origNsJSON = importCimcoreNSFile(ns);
-      expect(JSON.stringify(cimcoreSpecifications.namespaces[ns], null, 2)).to.eql(origNsJSON);
-    }
-
-    //data elements
-    for (const de of cimcoreSpecifications.dataElements) { //namespace files
-      const origDeJSON = importCimcoreDEFile(de.namespace, de.name);
-      expect(JSON.stringify(de, null, 2)).to.eql(origDeJSON);
-    }
-
-    //valuesets
-    for (const vs of cimcoreSpecifications.valueSets) {
-      const origVsJSON = importCimcoreVSFile(vs.namespace, vs.name);
-      expect(JSON.stringify(vs, null, 2)).to.eql(origVsJSON);
-    }
-
-    //mappings
-    for (const mapping of [...cimcoreSpecifications.mappings]) {
-      const origMapJSON = importCimcoreMapFile(mapping.namespace, mapping.name);
-      expect(JSON.stringify(mapping, null, 2)).to.eql(origMapJSON);
-    }
-
-  });
-});
+/* MK - cutting out CIMCORE tests because the examples are out of date, in Grammar 5. If we revive this, it should live in a separate file (e.g., import-cimcore-test.js).
+ mlt: - moved cimcore tests to import-cimcore-test.js.
 */
 
 // mlt: decoupled all shared function tests. Now located in import-helper.js


### PR DESCRIPTION
there are currently no CIMCORE tests to run as the test samples need migration to CIMPL6 grammar and also aligned with current SHR models.

This change is to just make the import-test.js file cleaner.