### PR TITLE
Added tests for checking constraints on substituted attributes

### DIFF
--- a/test/fixtures/dataElement/InvalidReferenceToSubstitutedName.txt
+++ b/test/fixtures/dataElement/InvalidReferenceToSubstitutedName.txt
@@ -1,0 +1,22 @@
+Grammar:    DataElement 6.0
+Namespace:  invalidReferenceToSubstitutedNameOut
+
+Element:    GroupBase
+Property:   Simple 0..*
+Property:   CodedFromValueSet 0..1
+
+Entry:      TypeConstraintOnField
+Parent:     GroupBase
+            Simple substitute Simple2
+            Simple 0..1  // this is invalid because the attribute is now Simple2
+            
+Element:      Simple
+Value:        string
+
+Element:      Simple2
+Parent:       Simple
+Value:        string
+
+Element:      CodedFromValueSet
+Value:        concept
+

--- a/test/fixtures/dataElement/SubstituteOnReferenceName.txt
+++ b/test/fixtures/dataElement/SubstituteOnReferenceName.txt
@@ -1,0 +1,21 @@
+Grammar:    DataElement 6.0
+Namespace:  substituteOnReferenceNameOut
+
+Element:    GroupBase
+Property:   Simple 0..*
+Property:   CodedFromValueSet 0..1
+
+Entry:      TypeConstraintOnField
+Parent:     GroupBase
+            Simple substitute Simple2
+            Simple2 0..1
+            
+Element:      Simple
+Value:        string
+
+Element:      Simple2
+Parent:       Simple
+Value:        string
+
+Element:      CodedFromValueSet
+Value:        concept

--- a/test/import-neg-test.js
+++ b/test/import-neg-test.js
@@ -122,6 +122,10 @@ describe('#importDataElementNegatives', () => {
     importFixture('InvalidChildProperty', true);
   }); 
 
+  it('Neg28: should produce an error message (not a traceback) when there is a reference to an attribute which has been substituted.', () => {
+    importFixture('InvalidReferenceToSubstitutedName', true);
+  }); 
+
 // end of negative examples  
 });
 

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -788,6 +788,25 @@ describe('#importDataElement', () => {
     expectConcept(choice.value.constraints[1].code, 'http://foo.org', 'baz');
     if(writeCIMPL6) specifications.toCIMPL6('../cimpl6-out');
   });
+
+  it('Import55: should correctly import a group with a cardinality constraint on a substituted element', () => {
+    const specifications = importFixture('SubstituteOnReferenceName');
+    const group = expectAndGetEntry(specifications, 'substituteOnReferenceNameOut', 'TypeConstraintOnField');
+    expect(group.basedOn).to.have.length(1);
+    expectIdentifier(group.basedOn[0], 'substituteOnReferenceNameOut', 'GroupBase');
+    expect(group.value).to.be.undefined;
+    expect(group.fields).to.have.length(2);
+    expectField(group, 0, 'substituteOnReferenceNameOut', 'Simple');
+    expect(group.fields[0].constraints).to.have.length(1);  // mlt: there are 2 constraints in Entry: one TypeConstraint and now one CardConstraint.
+    expect(group.fields[0].constraints[0]).to.be.instanceof(TypeConstraint);
+    expect(group.fields[0].constraints[0].path).to.be.empty;
+    expect(group.fields[0].constraints[0].onValue).to.be.false;
+    expectIdentifier(group.fields[0].constraints[0].isA, 'substituteOnReferenceNameOut', 'Simple2');
+    expect(group.fields[0].constraints[1]).to.be.instanceof(CardConstraint);
+    expect(group.fields[0].constraints[1].card.min).to.equal(0);
+    expect(group.fields[0].constraints[1].card.max).to.equal(1);
+    if(writeCIMPL6) specifications.toCIMPL6('../cimpl6-out');
+  });
 });
 
 


### PR DESCRIPTION
Test names added: Import55 and Neg28.  Both tests currently fail but the test samples and logic were checked before the commit.