### PR TITLE
Fix symbol iterator and missing card

### DIFF
--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -557,6 +557,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       }
       return [min, max];
     }
+    // No card, but return [undefined, undefined] so spread assignment works
+    return [undefined, undefined];
   }
 
   resolveToIdentifierOrTBD(ctx) {

--- a/test/fixtures/dataElement/CodeConstraintOnFieldChild.txt
+++ b/test/fixtures/dataElement/CodeConstraintOnFieldChild.txt
@@ -12,7 +12,7 @@ Element:        Simple
 Value:          string
 
 Element:        CodedFromValueSet
-Property:       CodedFromVS2
+Property:       CodedFromVS2 0..1
 
 Element:        CodedFromVS2
 Value:          concept from http://standardhealthrecord.org/test/vs/Coded (required)


### PR DESCRIPTION
Fixes six tests.  Five that failed with an error message about `Symbol.iterator` and one that failed due to a syntax mistake in the fixture.  See individual commits for details.