### PR TITLE
Content Profile paths must use the effectiveIdentifier

### DIFF
--- a/lib/contentProfileListener.js
+++ b/lib/contentProfileListener.js
@@ -145,7 +145,7 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
           });
 
           let element;
-          if (value && value.identifier) {
+          if (value && value.effectiveIdentifier) {
             element = this._specs.dataElements.findByIdentifier(value.effectiveIdentifier);
           }
 

--- a/lib/contentProfileListener.js
+++ b/lib/contentProfileListener.js
@@ -128,25 +128,25 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
             const el = this._specs.dataElements.findByIdentifier(id);
             [el.value, ...el.fields].forEach(field => {
               const key = (field && field.identifier) ? field.identifier : 'value';
-              if (field && !fields.get(key)) fields.set(key, field);
+              if (field && !fields.has(key)) fields.set(key, field);
             });
           }
-          
-          let value = Array.from(fields.values()).find(field => {
-            let identifier;
 
+          let value = Array.from(fields.values()).find(field => {
             if (field instanceof IdentifiableValue) {
-              identifier = field.possibleIdentifiers.find(id => name === id.name);
+              // match name on effectiveIdentifier since CP requires author to use constrained type name
+              return field.effectiveIdentifier.name === name;
             } else if (field instanceof ChoiceValue) {
-              identifier = field.aggregateOptions.find(id => name === id.name);
+              // match name on one of the choice option's effectiveIdentifier
+              return field.aggregateOptions.some(o => o.effectiveIdentifier && o.effectiveIdentifier.name === name);
             }
 
-            return (identifier != null);
+            return false;
           });
 
           let element;
           if (value && value.identifier) {
-            element = this._specs.dataElements.findByIdentifier(value.identifier);
+            element = this._specs.dataElements.findByIdentifier(value.effectiveIdentifier);
           }
 
           if (element) {
@@ -167,6 +167,8 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
     if (path.length === names.length) {
       this._currentRule = new ContentProfileRule(path);
     } else {
+      // TODO: We may be able to help the author by suggesting fixes when the problem is that they referred to the old identifier instead of the effectiveIdentifier.
+      // This will require some rework of the above code to detect and remember this situation.
       logger.error('Path not found for %s: %s. ERROR_CODE:?????', this._currentDef.identifier.fqn, pathStr);
     }
   }
@@ -186,7 +188,7 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
     this._specs.contentProfiles.add(this._currentDef);
     this._currentDef = null;
   }
-  
+
   // NOTE: This function "borrowed" from shr-expand
   getRecursiveBasedOns(identifier, alreadyProcessed = []) {
     // If it's primitive or we've already processed this one, don't go further (avoid circular dependencies)


### PR DESCRIPTION
After discussion w/ Mark, we determined that CPs should always use the "effective identifiers" in the paths.  For example, if field Foo is constrained to SonOfFoo, then the CP path should use SonOfFoo.

In addition fixed an issue where the ChoiceValue options were being iterated as identifiers when they are really Values (that have identifiers).