### PR TITLE
Tweaks to Mark's PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.project
 /node_modules
 /out
+/test/build

--- a/lib/import.js
+++ b/lib/import.js
@@ -6,7 +6,7 @@ const {Preprocessor, VERSION, GRAMMAR_VERSION} = require('./preprocessor');
 const {DataElementImporter} = require('./dataElementListener');
 const {ValueSetImporter} = require('./valueSetListener');
 const {MappingImporter} = require('./mappingListener');
-//const {CimcoreImporter} = require('./cimcore/cimcoreImport');
+const {CimcoreImporter} = require('./cimcore/cimcoreImport');
 
 var logger = bunyan.createLogger({name: 'shr-text-import'});
 
@@ -16,7 +16,7 @@ function setLogger(bunyanLogger) {
   require('./dataElementListener').setLogger(logger);
   require('./valueSetListener').setLogger(logger);
   require('./mappingListener').setLogger(logger);
-//  require('./cimcore/cimcoreImport').setLogger(logger);
+  require('./cimcore/cimcoreImport').setLogger(logger);
 }
 
 function importFromFilePath(filePath, configuration=[], specifications = new Specifications()) {
@@ -74,7 +74,6 @@ function importConfigFromFilePath(filePath, configName) {
   return configuration;
 }
 
-/*
 function importCIMCOREFromFilePath(filePath) {
   const importer = new CimcoreImporter();
   importer.readFiles(filePath);
@@ -82,7 +81,6 @@ function importCIMCOREFromFilePath(filePath) {
   const importedSpecs = importer.convertToSpecifications();
   return [configSpecs, importedSpecs];
 }
-*/
 
 function processPath(filePath, filesByType = new FilesByType()) {
   const stats = fs.statSync(filePath);
@@ -163,4 +161,4 @@ class FilesByType {
   }
 }
 
-module.exports = {importFromFilePath, importConfigFromFilePath, /*importCIMCOREFromFilePath,*/ VERSION, GRAMMAR_VERSION, setLogger, MODELS_INFO};
+module.exports = {importFromFilePath, importConfigFromFilePath, importCIMCOREFromFilePath, VERSION, GRAMMAR_VERSION, setLogger, MODELS_INFO};

--- a/test/import-cimcore-test.js
+++ b/test/import-cimcore-test.js
@@ -1,54 +1,50 @@
-const fs = require('fs');
 const {expect} = require('chai');
 const {setLogger} = require('../index');
 
-// ** mlt: uncomment the next 2 lines once we have actual test samples to verify.
-// const {id, pid, expectAndGetElement, expectAndGetEntry, expectValue, expectPrimitiveValue, expectChoiceValue, expectCardOne, expectChoiceOption, expectField, expectConcept, expectIdentifier, expectPrimitiveIdentifier, expectNoConstraints, importFixture, importFixtureFolder } = require('../test/import-helper');
-// const {Version, IncompleteValue, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, CardConstraint, TBD, REQUIRED, EXTENSIBLE, PREFERRED, EXAMPLE} = require('shr-models');
+const {importCimcoreFolder, importCimcoreProjectFile, importCimcoreNSFile, importCimcoreDEFile, importCimcoreVSFile, importCimcoreMapFile, convertSpecsToCimcore} = require('../test/import-helper');
 const err = require('shr-test-helpers/errors');
+setLogger(err.logger());
 
 // mlt: All of the cimcore test samples need updating to CIMPL6 grammar
 
-/*
-describe('#importCimcoreFromFilePath', () => {
-    it('Cimcore1: should be able to correctly import specifications instance and then export to identical cimcore', () => {
-      const [importedConfigSpecifications, importedSpecifications] = importCimcoreFolder();
-  
-      //This is the cimcore produced from importedSpecs. Used for verifying fidelity
-      const cimcoreSpecifications = convertSpecsToCimcore(importedConfigSpecifications, importedSpecifications);
-  
-      //All CIMCORE files are verified through string comparison. This is perhaps not ideal as they can still be
-      //valid files if the same elemenets are outputted in a different order. However, this should not be a problem
-      //for now, as the process that produced the original fixtures and the process that produces the unit test are
-      //identical in their ordering of outputs. This change should be a considered update in the future.
-  
-      const origProjectJSON = importCimcoreProjectFile();
-      expect(JSON.stringify(cimcoreSpecifications.projectInfo, null, 2)).to.eql(origProjectJSON);
-  
-      //meta namespace files
-      for (const ns in cimcoreSpecifications.namespaces) { //namespace files
-        const origNsJSON = importCimcoreNSFile(ns);
-        expect(JSON.stringify(cimcoreSpecifications.namespaces[ns], null, 2)).to.eql(origNsJSON);
-      }
-  
-      //data elements
-      for (const de of cimcoreSpecifications.dataElements) { //namespace files
-        const origDeJSON = importCimcoreDEFile(de.namespace, de.name);
-        expect(JSON.stringify(de, null, 2)).to.eql(origDeJSON);
-      }
-  
-      //valuesets
-      for (const vs of cimcoreSpecifications.valueSets) {
-        const origVsJSON = importCimcoreVSFile(vs.namespace, vs.name);
-        expect(JSON.stringify(vs, null, 2)).to.eql(origVsJSON);
-      }
-  
-      //mappings
-      for (const mapping of [...cimcoreSpecifications.mappings]) {
-        const origMapJSON = importCimcoreMapFile(mapping.namespace, mapping.name);
-        expect(JSON.stringify(mapping, null, 2)).to.eql(origMapJSON);
-      }
-  
-    });
+describe.skip('#importCimcoreFromFilePath', () => {
+  it('Cimcore1: should be able to correctly import specifications instance and then export to identical cimcore', () => {
+    const [importedConfigSpecifications, importedSpecifications] = importCimcoreFolder();
+
+    //This is the cimcore produced from importedSpecs. Used for verifying fidelity
+    const cimcoreSpecifications = convertSpecsToCimcore(importedConfigSpecifications, importedSpecifications);
+
+    //All CIMCORE files are verified through string comparison. This is perhaps not ideal as they can still be
+    //valid files if the same elemenets are outputted in a different order. However, this should not be a problem
+    //for now, as the process that produced the original fixtures and the process that produces the unit test are
+    //identical in their ordering of outputs. This change should be a considered update in the future.
+
+    const origProjectJSON = importCimcoreProjectFile();
+    expect(JSON.stringify(cimcoreSpecifications.projectInfo, null, 2)).to.eql(origProjectJSON);
+
+    //meta namespace files
+    for (const ns in cimcoreSpecifications.namespaces) { //namespace files
+      const origNsJSON = importCimcoreNSFile(ns);
+      expect(JSON.stringify(cimcoreSpecifications.namespaces[ns], null, 2)).to.eql(origNsJSON);
+    }
+
+    //data elements
+    for (const de of cimcoreSpecifications.dataElements) { //namespace files
+      const origDeJSON = importCimcoreDEFile(de.namespace, de.name);
+      expect(JSON.stringify(de, null, 2)).to.eql(origDeJSON);
+    }
+
+    //valuesets
+    for (const vs of cimcoreSpecifications.valueSets) {
+      const origVsJSON = importCimcoreVSFile(vs.namespace, vs.name);
+      expect(JSON.stringify(vs, null, 2)).to.eql(origVsJSON);
+    }
+
+    //mappings
+    for (const mapping of [...cimcoreSpecifications.mappings]) {
+      const origMapJSON = importCimcoreMapFile(mapping.namespace, mapping.name);
+      expect(JSON.stringify(mapping, null, 2)).to.eql(origMapJSON);
+    }
+
   });
-  */
+});

--- a/test/import-helper.js
+++ b/test/import-helper.js
@@ -186,9 +186,6 @@ function emptyThenRmdir(dir_path) {
   }
 }
 
-module.exports = {id, pid, expectAndGetElement, expectAndGetEntry, expectAndGetDataElement, expectValue, expectPrimitiveValue, expectRefValue, expectChoiceValue, expectMinMax, expectCardOne, expectChoiceOption, expectField, expectConcept, expectIdentifier, expectPrimitiveIdentifier, expectNoConstraints, importFixture, importFixtureFolder, importConfiguration, importConfigurationFolder, checkImportErrors, toCIMPL6, testCIMPL6Export, emptyThenRmdir };
-
-/*
 function importCimcoreNSFile(namespace, numExpectedErrors = 0) {
   namespace = namespace.replace(/\./g,'-');
   const configuration = fs.readFileSync(`${__dirname}/fixtures/cimcore/${namespace}/${namespace}.json`, 'utf8');
@@ -278,8 +275,4 @@ function convertSpecsToCimcore(configSpecifications, expSpecifications) {
   return cimcoreSpecifications;
 }
 
-module.exports = {id, pid, expectAndGetElement, expectAndGetEntry, expectAndGetDataElement, expectValue, expectPrimitiveValue, expectRefValue, expectChoiceValue, expectMinMax, expectCardOne, expectChoiceOption, expectField, expectConcept, expectIdentifier, expectPrimitiveIdentifier, expectNoConstraints, importFixture, importFixtureFolder, importConfiguration, importConfigurationFolder, importCimcoreNSFile, importCimcoreDEFile, importCimcoreVSFile, importCimcoreMapFile, importCimcoreProjectFile, importCimcoreFolder, checkImportErrors, convertSpecsToCimcore };
-
-*/
-
-
+module.exports = {id, pid, expectAndGetElement, expectAndGetEntry, expectAndGetDataElement, expectValue, expectPrimitiveValue, expectRefValue, expectChoiceValue, expectMinMax, expectCardOne, expectChoiceOption, expectField, expectConcept, expectIdentifier, expectPrimitiveIdentifier, expectNoConstraints, importFixture, importFixtureFolder, importConfiguration, importConfigurationFolder, checkImportErrors, toCIMPL6, testCIMPL6Export, emptyThenRmdir, importCimcoreNSFile, importCimcoreDEFile, importCimcoreVSFile, importCimcoreMapFile, importCimcoreProjectFile, importCimcoreFolder, convertSpecsToCimcore };

--- a/test/import-helper.js
+++ b/test/import-helper.js
@@ -1,11 +1,9 @@
 const fs = require('fs');
-var path = require('path');
 const {expect} = require('chai');
-const {importFromFilePath, importConfigFromFilePath, importCIMCOREFromFilePath, setLogger} = require('../index');
+const {importFromFilePath, importConfigFromFilePath, importCIMCOREFromFilePath} = require('../index');
 const {DataElement, Value, RefValue, ChoiceValue, Identifier, PrimitiveIdentifier, Cardinality, toCIMPL6} = require('shr-models');
 const err = require('shr-test-helpers/errors');
-const shrexpand = require('shr-expand');
-const expand = shrexpand.expand;
+const {expand} = require('shr-expand');
 
 // Shorthand Identifier constructor for more concise code
 function id(namespace, name) {
@@ -118,14 +116,14 @@ function expectNoConstraints(value) {
   }
 }
 
-function importFixture(name, dir = "/fixtures/dataElement/", hasExpectedErrors = false) {
+function importFixture(name, dir = '/fixtures/dataElement/', hasExpectedErrors = false) {
   const dependencies = importFromFilePath(`${__dirname}/fixtures/dataElement/_dependencies`);
-  const specifications = importFromFilePath(`${__dirname}`+dir+`${name}.txt`, null, dependencies);  
+  const specifications = importFromFilePath(`${__dirname}`+dir+`${name}.txt`, null, dependencies);
   checkImportErrors(hasExpectedErrors);
   return specifications;
 }
 
-function importFixtureFolder(name, dir = "/fixtures/dataElement/", hasExpectedErrors = false) {
+function importFixtureFolder(name, dir = '/fixtures/dataElement/', hasExpectedErrors = false) {
   const dependencies = importFromFilePath(`${__dirname}/fixtures/dataElement/_dependencies`);
   const specifications = importFromFilePath(`${__dirname}`+dir+`${name}`, null, dependencies);
   checkImportErrors(hasExpectedErrors);
@@ -158,7 +156,7 @@ function checkImportErrors(hasExpectedErrors) {
   }
 }
 
-function testCIMPL6Export(specifications, exportDir = '/fixtures/dataElementExports/') {
+function testCIMPL6Export(specifications, exportDir = '/build/dataElementExports/') {
   specifications = expand(specifications);
   const expandErrors = err.errors();
   if(expandErrors.length > 0) expect(false, `shr-expand: ${expandErrors.map(e => e.msg).join('; ')}`).to.be.true;
@@ -172,6 +170,7 @@ function testCIMPL6Export(specifications, exportDir = '/fixtures/dataElementExpo
  * @param {string} dir_path
  * @see https://stackoverflow.com/a/42505874/3027390
  */
+/* NOT YET TESTED
 function emptyThenRmdir(dir_path) {
   if (fs.existsSync(dir_path)) {
       fs.readdirSync(dir_path).forEach(function(entry) {
@@ -185,6 +184,7 @@ function emptyThenRmdir(dir_path) {
       fs.rmdirSync(dir_path);
   }
 }
+*/
 
 function importCimcoreNSFile(namespace, numExpectedErrors = 0) {
   namespace = namespace.replace(/\./g,'-');
@@ -275,4 +275,4 @@ function convertSpecsToCimcore(configSpecifications, expSpecifications) {
   return cimcoreSpecifications;
 }
 
-module.exports = {id, pid, expectAndGetElement, expectAndGetEntry, expectAndGetDataElement, expectValue, expectPrimitiveValue, expectRefValue, expectChoiceValue, expectMinMax, expectCardOne, expectChoiceOption, expectField, expectConcept, expectIdentifier, expectPrimitiveIdentifier, expectNoConstraints, importFixture, importFixtureFolder, importConfiguration, importConfigurationFolder, checkImportErrors, toCIMPL6, testCIMPL6Export, emptyThenRmdir, importCimcoreNSFile, importCimcoreDEFile, importCimcoreVSFile, importCimcoreMapFile, importCimcoreProjectFile, importCimcoreFolder, convertSpecsToCimcore };
+module.exports = {id, pid, expectAndGetElement, expectAndGetEntry, expectAndGetDataElement, expectValue, expectPrimitiveValue, expectRefValue, expectChoiceValue, expectMinMax, expectCardOne, expectChoiceOption, expectField, expectConcept, expectIdentifier, expectPrimitiveIdentifier, expectNoConstraints, importFixture, importFixtureFolder, importConfiguration, importConfigurationFolder, checkImportErrors, toCIMPL6, testCIMPL6Export, /*emptyThenRmdir,*/ importCimcoreNSFile, importCimcoreDEFile, importCimcoreVSFile, importCimcoreMapFile, importCimcoreProjectFile, importCimcoreFolder, convertSpecsToCimcore };

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -1,11 +1,9 @@
-const fs = require('fs');
 const {expect} = require('chai');
 const {setLogger} = require('../index');
 const {id, pid, expectAndGetElement, expectAndGetEntry, expectValue, expectPrimitiveValue, expectChoiceValue, expectCardOne, expectChoiceOption, expectField, expectConcept, expectIdentifier, expectPrimitiveIdentifier, expectNoConstraints, importFixture, importFixtureFolder, testCIMPL6Export } = require('../test/import-helper');
 const {Version, IncompleteValue, ValueSetConstraint, CodeConstraint, IncludesCodeConstraint, BooleanConstraint, TypeConstraint, CardConstraint, TBD, REQUIRED, EXTENSIBLE, PREFERRED, EXAMPLE} = require('shr-models');
 const err = require('shr-test-helpers/errors');
 const shrexpand = require('shr-expand');
-const expand = shrexpand.expand;
 const errorLogger = err.logger();
 
 shrexpand.setLogger(errorLogger)
@@ -14,8 +12,6 @@ setLogger(errorLogger);
 
 //------------------- Controlling the Tests -------------------------
 
-// PHASE 1: Run import tests (always true)
-const phase1 = true; 
 // PHASE 2: Expand and Export: Write the re-constituted files to dataElementExports
 const phase2 = true;
 // PHASE 3 (comment out if not desired): This re-runs the tests by importing the files that were exported to dataElementExports (only valid if files were exported in phase 1)
@@ -23,10 +19,10 @@ const phase3 = true;
 
 //------------------- The Tests -------------------------
 
-testImportExport(phase2, "/fixtures/dataElement/", '#importDataElement');
-testImportExport(phase3, "/fixtures/dataElementExports/", "#re-importExportedFiles");
+testImportExport(phase2, '/fixtures/dataElement/', '#importDataElement');
+testImportExport(phase3, '/build/dataElementExports/', '#re-importExportedFiles');
 // removal of exports directory is not yet tested
-// emptyThenRmdir(`${__dirname}/fixtures/dataElementExports');
+// emptyThenRmdir(`${__dirname}/build/dataElementExports');
 
 
 


### PR DESCRIPTION
I made a few tweaks, namely:
- re-enabled the CIMCORE import and SKIPPED CIMCORE import tests (instead of commenting out)
- moved the exported CIMPL6 files out of `fixtures` and into `build`
- tweaked some minor ESLint issues

There are still other ESLint issues in the tests (due to indentation, undeclared variables), but I'm ignoring them for now.  I expect we'll clean all that up before merging to master.

@markkramerus -- if you agree with these changes then I will merge them into your branch (or you can) -- and then I will merge your branch into `cimpl6Import`.