### PR TITLE
Trim spaces from codes

### DIFF
--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -419,7 +419,7 @@ class DataElementImporter extends SHRDataElementParserListener {
     if (ctx.fullyQualifiedCode()) {
       code = this.processFullyQualifiedCode(ctx.fullyQualifiedCode());
     } else if (ctx.code()) {
-      code = new Concept(null, ctx.code().CODE().getText().substr(1)); // substr to skip the '#'
+      code = new Concept(null, ctx.code().CODE().getText().substr(1).trim()); // substr to skip the '#'
       if (ctx.code().STRING()) {
         code.display = stripDelimitersFromToken(ctx.code().STRING());
       }
@@ -438,7 +438,7 @@ class DataElementImporter extends SHRDataElementParserListener {
       } else {
         cs = resolution.url;
       }
-      const code = ctx.code().CODE().getText().substr(1); // substr to skip the '#'
+      const code = ctx.code().CODE().getText().substr(1).trim(); // substr to skip the '#'
       const concept = new Concept(cs, code);
       if (ctx.code().STRING()) {
         concept.display = stripDelimitersFromToken(ctx.code().STRING());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-text-import",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "Imports Standard Health Record (SHR) elements from their custom grammar to the SHR models",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The way some CIMPL definitions have been written recently, the importer ends up leaving whitespace at the end of codes.  This trims it.