### PR TITLE
Sprint 41 Changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^3.6.1",
     "mocha": "^3.5.3",
     "shr-expand": "^6.0.0",
-    "shr-models": "standardhealth/shr-models#add-fixed-value-constraint",
+    "shr-models": "standardhealth/shr-models#cm_sprint_41",
     "shr-test-helpers": "^6.0.0"
   },
   "peerDependencies": {

--- a/test/fixtures/cimcore/cimi-adverse/cimi-adverse-ActionTaken.json
+++ b/test/fixtures/cimcore/cimi-adverse/cimi-adverse-ActionTaken.json
@@ -8,7 +8,7 @@
   "description": "The action taken as a result of the adverse reaction. May include changing or discontinuing medication, reducing dose, etc.",
   "fields": [
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/cimi-adverse/cimi-adverse-AdverseEventAttribution.json
+++ b/test/fixtures/cimcore/cimi-adverse/cimi-adverse-AdverseEventAttribution.json
@@ -21,7 +21,7 @@
     },
     "options": [
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue",
         "constraints": {
           "valueSet": {

--- a/test/fixtures/cimcore/cimi-adverse/cimi-adverse-AdverseEventGrade.json
+++ b/test/fixtures/cimcore/cimi-adverse/cimi-adverse-AdverseEventGrade.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-adverse/cimi-adverse-AdverseEventPresenceContext.json
+++ b/test/fixtures/cimcore/cimi-adverse/cimi-adverse-AdverseEventPresenceContext.json
@@ -27,7 +27,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/context/vs/PresenceContextVS",
               "bindingStrength": "REQUIRED",
@@ -137,7 +137,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/adverse-event-outcome",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-adverse/cimi-adverse-AdverseEventTopic.json
+++ b/test/fixtures/cimcore/cimi-adverse/cimi-adverse-AdverseEventTopic.json
@@ -26,7 +26,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/adverse/vs/MedDRAVS",
               "bindingStrength": "REQUIRED",
@@ -65,7 +65,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-adverse/cimi-adverse-CauseCategory.json
+++ b/test/fixtures/cimcore/cimi-adverse/cimi-adverse-CauseCategory.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Whether the adverse event is attributed to a treatment, course of the disease, unrelated to either, or unknown.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-adverse/cimi-adverse-SeriousAdverseEvent.json
+++ b/test/fixtures/cimcore/cimi-adverse/cimi-adverse-SeriousAdverseEvent.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,7 +21,7 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/YesNoUnknownVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/YesNoUnknownVS",
         "bindingStrength": "REQUIRED",
         "lastModifiedBy": "cimi.adverse.SeriousAdverseEvent"
       }

--- a/test/fixtures/cimcore/cimi-adverse/cimi-adverse-ToxicReaction.json
+++ b/test/fixtures/cimcore/cimi-adverse/cimi-adverse-ToxicReaction.json
@@ -189,7 +189,7 @@
         "subpaths": {
           "cimi.adverse.AdverseEventGrade": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/cimi/adverse/vs/ToxicReactionVS",
                   "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-adverse/mappings/AdverseEventPresenceStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-adverse/mappings/AdverseEventPresenceStatement-mapping.json
@@ -27,7 +27,7 @@
       {
         "sourcePath": [
           "cimi.adverse.AdverseEventTopic",
-          "shr.core.Details"
+          "obf.datatype.Details"
         ],
         "target": "description",
         "lastModifiedBy": "cimi.adverse.AdverseEventPresenceStatement"

--- a/test/fixtures/cimcore/cimi-adverse/mappings/ToxicReaction-mapping.json
+++ b/test/fixtures/cimcore/cimi-adverse/mappings/ToxicReaction-mapping.json
@@ -31,7 +31,7 @@
       {
         "sourcePath": [
           "cimi.adverse.AdverseEventTopic",
-          "shr.core.Details"
+          "obf.datatype.Details"
         ],
         "target": "description",
         "lastModifiedBy": "cimi.adverse.AdverseEventPresenceStatement"

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Abatement.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Abatement.json
@@ -24,7 +24,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Age",
+        "fqn": "obf.datatype.Age",
         "valueType": "IdentifiableValue"
       },
       {
@@ -32,11 +32,11 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Range",
+        "fqn": "obf.datatype.Range",
         "valueType": "IdentifiableValue"
       },
       {

--- a/test/fixtures/cimcore/cimi-context/cimi-context-AbsenceContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-AbsenceContext.json
@@ -25,7 +25,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/context/vs/AbsenceContextVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-context/cimi-context-AtRiskContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-AtRiskContext.json
@@ -31,7 +31,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/context/vs/AtRiskContextVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Certainty.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Certainty.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The degree of confidence in a conclusion or assertion.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-CommunicationMethod.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-CommunicationMethod.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "This is the method the provider used to communicate. Examples include: Written, Telephoned, Verbal, Electronically Entered, Policy, Service Correction, Duplicate, etc. 'Code indicating the origin of the prescription.' - NCPDP Telecommunication (Field 419-DJ, Data Dictionary 201104). Possible values include: Written; Telephone; Electronic; Facsimile; Pharmacy; Not Known.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-ConditionPresenceContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-ConditionPresenceContext.json
@@ -27,7 +27,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/context/vs/PresenceContextVS",
               "bindingStrength": "REQUIRED",
@@ -168,7 +168,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/condition-severity",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-context/cimi-context-ContextCode.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-ContextCode.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A code representing the ontological status of the statement, e.g., whether it exists, does not exist, is planned, etc.\nAttribute aligns with the SNOMED CT Situation with Explicit Context (SWEC) Concept Model context attributes: 'Finding context (attribute)' (SCTID: 408729009) and 'Procedure context (attribute)' (SCTID: 408730004). The range allowed for this attribute shall be consistent with the SNOMED CT concept model specification for SWEC.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-DeltaFlag.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-DeltaFlag.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-EvaluationResultRecordedContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-EvaluationResultRecordedContext.json
@@ -26,7 +26,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {
@@ -124,7 +124,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/context/vs/ExceptionValueVS",
               "bindingStrength": "EXTENSIBLE",

--- a/test/fixtures/cimcore/cimi-context/cimi-context-ExceptionValue.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-ExceptionValue.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Reason that a value associated with a test or other finding is missing.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-ExpectationContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-ExpectationContext.json
@@ -31,7 +31,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/context/vs/ExpectationContextVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-context/cimi-context-ExpectedPerformanceTime.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-ExpectedPerformanceTime.json
@@ -22,11 +22,11 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Timing",
+        "fqn": "obf.datatype.Timing",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-context/cimi-context-ExpectedPerformerType.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-ExpectedPerformerType.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "What type of party should carry out the testing.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-GoalContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-GoalContext.json
@@ -31,7 +31,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/context/vs/GoalContextVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Interpretation.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Interpretation.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Method.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Method.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The technique used to carry out an action, for example, the specific imaging technical or assessment vehicle.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-NotPerformedContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-NotPerformedContext.json
@@ -48,7 +48,7 @@
       }
     },
     {
-      "fqn": "shr.core.NonOccurrenceTimeOrPeriod",
+      "fqn": "obf.datatype.NonOccurrenceTimeOrPeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Onset.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Onset.json
@@ -24,15 +24,15 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Age",
+        "fqn": "obf.datatype.Age",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Range",
+        "fqn": "obf.datatype.Range",
         "valueType": "IdentifiableValue"
       },
       {

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Outcome.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Outcome.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The result of performing an action or behavior, for example, an adverse reaction or new finding.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-ParticipationPeriod.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-ParticipationPeriod.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The point in time or span of time the participant is involved.",
   "value": {
-    "fqn": "shr.core.TimePeriod",
+    "fqn": "obf.datatype.TimePeriod",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-ParticipationType.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-ParticipationType.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-PerformedContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-PerformedContext.json
@@ -40,7 +40,7 @@
       }
     },
     {
-      "fqn": "shr.core.OccurrenceTimeOrPeriod",
+      "fqn": "obf.datatype.OccurrenceTimeOrPeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Preexisting.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Preexisting.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "If the problem or condition existed before the current episode of care.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -15,7 +15,7 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/YesNoUnknownVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/YesNoUnknownVS",
         "bindingStrength": "REQUIRED",
         "lastModifiedBy": "cimi.context.Preexisting"
       }

--- a/test/fixtures/cimcore/cimi-context/cimi-context-PresenceContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-PresenceContext.json
@@ -32,7 +32,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/context/vs/PresenceContextVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Reason.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Reason.json
@@ -24,7 +24,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       },
       {

--- a/test/fixtures/cimcore/cimi-context/cimi-context-RecordedContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-RecordedContext.json
@@ -25,7 +25,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/cimi-context/cimi-context-RelevantTime.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-RelevantTime.json
@@ -18,7 +18,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-context/cimi-context-RequestedContext.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-RequestedContext.json
@@ -125,7 +125,7 @@
       }
     },
     {
-      "fqn": "shr.core.PriorityRank",
+      "fqn": "obf.datatype.PriorityRank",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -133,7 +133,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/request-priority",
               "bindingStrength": "PREFERRED",

--- a/test/fixtures/cimcore/cimi-context/cimi-context-ResultValue.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-ResultValue.json
@@ -14,11 +14,11 @@
     },
     "options": [
       {
-        "fqn": "shr.core.Quantity",
+        "fqn": "obf.datatype.Quantity",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       },
       {
@@ -30,11 +30,11 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Range",
+        "fqn": "obf.datatype.Range",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Ratio",
+        "fqn": "obf.datatype.Ratio",
         "valueType": "IdentifiableValue"
       },
       {
@@ -46,7 +46,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Severity.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Severity.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-Stage.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-Stage.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-context/cimi-context-VerificationStatus.json
+++ b/test/fixtures/cimcore/cimi-context/cimi-context-VerificationStatus.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Whether an assessment has been confirmed by testing or observation.\nCIMI Alignment: This attribute corresponds to FindingContext.status, but has been defined to align with FHIR. In AllergyIntolerance, the type is code.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-core/cimi-core-RecordStatus.json
+++ b/test/fixtures/cimcore/cimi-core/cimi-core-RecordStatus.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Concept indicating the state of this record, e.g., 'entered in error'.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-core/cimi-core-RelationshipToPersonOfRecord.json
+++ b/test/fixtures/cimcore/cimi-core/cimi-core-RelationshipToPersonOfRecord.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The relationship of the SubjectOfInformation to the subject of record.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-AnatomicalDirection.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-AnatomicalDirection.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-AnatomicalLocation.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-AnatomicalLocation.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-Annotation.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-Annotation.json
@@ -24,7 +24,7 @@
       }
     },
     {
-      "fqn": "shr.core.OccurrenceTime",
+      "fqn": "obf.datatype.OccurrenceTime",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-Identifier.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-Identifier.json
@@ -22,7 +22,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -30,7 +30,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/identifier-use",
               "bindingStrength": "REQUIRED",
@@ -41,7 +41,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -49,7 +49,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/identifier-type",
               "bindingStrength": "EXTENSIBLE",
@@ -60,7 +60,7 @@
       }
     },
     {
-      "fqn": "shr.core.CodeSystem",
+      "fqn": "obf.datatype.CodeSystem",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-Laterality.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-Laterality.json
@@ -14,7 +14,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-Match.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-Match.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The relative match of the mapped concept to the original (target) concept. Examples include broader (i.e., the mapped term is more general than the original), equivalent, narrower (e.g. mapped concept is 'atypical diabetes mellitus' and the original term is 'diabetes mellitus'), or unknown.",
   "value": {
-    "fqn": "shr.core.Coding",
+    "fqn": "obf.datatype.Coding",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-Name.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-Name.json
@@ -16,14 +16,14 @@
       }
     },
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-PersonName.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-PersonName.json
@@ -32,7 +32,7 @@
       }
     },
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -51,7 +51,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/name-use",
               "bindingStrength": "REQUIRED",
@@ -88,7 +88,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-PreferredFlag.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-PreferredFlag.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Code indicating the preference associated with the use of this name.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-RouteIntoBody.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-RouteIntoBody.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-Signature.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-Signature.json
@@ -15,7 +15,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/signature-type",
               "bindingStrength": "EXTENSIBLE",
@@ -26,7 +26,7 @@
       }
     },
     {
-      "fqn": "shr.core.CreationTime",
+      "fqn": "obf.datatype.CreationTime",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "fqn": "shr.core.ContentType",
+      "fqn": "obf.datatype.ContentType",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -58,7 +58,7 @@
       }
     },
     {
-      "fqn": "shr.core.BinaryData",
+      "fqn": "obf.datatype.BinaryData",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-SignatureType.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-SignatureType.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.Coding",
+    "fqn": "obf.datatype.Coding",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-element/cimi-element-Status.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-Status.json
@@ -24,11 +24,11 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Coding",
+        "fqn": "obf.datatype.Coding",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-element/cimi-element-TermMapping.json
+++ b/test/fixtures/cimcore/cimi-element/cimi-element-TermMapping.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Represents an alternative (mapped) Concept associated with a source concept (i.e., CodedText.concept or the textual value of the CodedText when no equivalent concept has been defined), and the relative match of the mapped Concept with respect to the source Concept. Mappings may be used to add classification terms (e.g. adding ICD classifiers to SNOMED descriptive terms), for computational convenience, or to provide equivalents in other terminologies (e.g. across nursing vocabularies).",
   "value": {
-    "fqn": "shr.core.Coding",
+    "fqn": "obf.datatype.Coding",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -24,7 +24,7 @@
       }
     },
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-element/mappings/AnatomicalLocation-mapping.json
+++ b/test/fixtures/cimcore/cimi-element/mappings/AnatomicalLocation-mapping.json
@@ -9,7 +9,7 @@
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.CodeableConcept"
+          "obf.datatype.CodeableConcept"
         ],
         "target": "code",
         "lastModifiedBy": "cimi.element.AnatomicalLocation"

--- a/test/fixtures/cimcore/cimi-element/mappings/Annotation-mapping.json
+++ b/test/fixtures/cimcore/cimi-element/mappings/Annotation-mapping.json
@@ -23,7 +23,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.OccurrenceTime"
+          "obf.datatype.OccurrenceTime"
         ],
         "target": "time",
         "lastModifiedBy": "cimi.element.Annotation"

--- a/test/fixtures/cimcore/cimi-element/mappings/Identifier-mapping.json
+++ b/test/fixtures/cimcore/cimi-element/mappings/Identifier-mapping.json
@@ -16,28 +16,28 @@
       },
       {
         "sourcePath": [
-          "shr.core.Purpose"
+          "obf.datatype.Purpose"
         ],
         "target": "use",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.CodeSystem"
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
         "lastModifiedBy": "cimi.element.Identifier"

--- a/test/fixtures/cimcore/cimi-element/mappings/Signature-mapping.json
+++ b/test/fixtures/cimcore/cimi-element/mappings/Signature-mapping.json
@@ -16,7 +16,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "when",
         "lastModifiedBy": "cimi.element.Signature"
@@ -37,14 +37,14 @@
       },
       {
         "sourcePath": [
-          "shr.core.ContentType"
+          "obf.datatype.ContentType"
         ],
         "target": "contentType",
         "lastModifiedBy": "cimi.element.Signature"
       },
       {
         "sourcePath": [
-          "shr.core.BinaryData"
+          "obf.datatype.BinaryData"
         ],
         "target": "blob",
         "lastModifiedBy": "cimi.element.Signature"

--- a/test/fixtures/cimcore/cimi-encounter/cimi-encounter-DetailedEncounter.json
+++ b/test/fixtures/cimcore/cimi-encounter/cimi-encounter-DetailedEncounter.json
@@ -152,7 +152,7 @@
       }
     },
     {
-      "fqn": "shr.core.TimePeriod",
+      "fqn": "obf.datatype.TimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-encounter/cimi-encounter-Diagnosis.json
+++ b/test/fixtures/cimcore/cimi-encounter/cimi-encounter-Diagnosis.json
@@ -16,7 +16,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.PriorityRank",
+      "fqn": "obf.datatype.PriorityRank",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -24,7 +24,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -32,7 +32,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/diagnosis-role",
               "bindingStrength": "PREFERRED",

--- a/test/fixtures/cimcore/cimi-encounter/cimi-encounter-Encounter.json
+++ b/test/fixtures/cimcore/cimi-encounter/cimi-encounter-Encounter.json
@@ -144,7 +144,7 @@
       }
     },
     {
-      "fqn": "shr.core.TimePeriod",
+      "fqn": "obf.datatype.TimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-encounter/cimi-encounter-EncounterClass.json
+++ b/test/fixtures/cimcore/cimi-encounter/cimi-encounter-EncounterClass.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Concepts representing classification of patient encounter such as ambulatory (outpatient), inpatient, emergency, home health or others due to local variations.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-encounter/cimi-encounter-EncounterType.json
+++ b/test/fixtures/cimcore/cimi-encounter/cimi-encounter-EncounterType.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Specific type of encounter (e.g. e-mail consultation, surgical day-care, skilled nursing, rehabilitation).",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-encounter/mappings/DetailedEncounter-mapping.json
+++ b/test/fixtures/cimcore/cimi-encounter/mappings/DetailedEncounter-mapping.json
@@ -34,7 +34,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.TimePeriod"
+          "obf.datatype.TimePeriod"
         ],
         "target": "period",
         "lastModifiedBy": "cimi.encounter.Encounter"

--- a/test/fixtures/cimcore/cimi-encounter/mappings/Encounter-mapping.json
+++ b/test/fixtures/cimcore/cimi-encounter/mappings/Encounter-mapping.json
@@ -30,7 +30,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.TimePeriod"
+          "obf.datatype.TimePeriod"
         ],
         "target": "period",
         "lastModifiedBy": "cimi.encounter.Encounter"

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-AccessionIdentifier.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-AccessionIdentifier.json
@@ -26,7 +26,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -34,7 +34,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/identifier-use",
               "bindingStrength": "REQUIRED",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -69,7 +69,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/identifier-type",
               "bindingStrength": "EXTENSIBLE",
@@ -96,7 +96,7 @@
       }
     },
     {
-      "fqn": "shr.core.CodeSystem",
+      "fqn": "obf.datatype.CodeSystem",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-ActiveFlagAsaCodeableConcept.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-ActiveFlagAsaCodeableConcept.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "If the ActiveFlag is false, it indicates the record or item is no longer to be used and should generally be hidden for the user in the UI.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Additive.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Additive.json
@@ -14,7 +14,7 @@
     },
     "options": [
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       },
       {

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-AgeAtDeath.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-AgeAtDeath.json
@@ -20,11 +20,11 @@
     },
     "options": [
       {
-        "fqn": "shr.core.Age",
+        "fqn": "obf.datatype.Age",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.AgeRange",
+        "fqn": "obf.datatype.AgeRange",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-AnonymizedFlag.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-AnonymizedFlag.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,7 +21,7 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/YesNoVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/YesNoVS",
         "bindingStrength": "REQUIRED",
         "lastModifiedBy": "cimi.entity.AnonymizedFlag"
       }

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-BirthSex.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-BirthSex.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Capacity.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Capacity.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Container volume or size.",
   "value": {
-    "fqn": "shr.core.SimpleQuantity",
+    "fqn": "obf.datatype.SimpleQuantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-CollectionMethod.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-CollectionMethod.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "How the specimen was obtained.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-CollectionTime.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-CollectionTime.json
@@ -18,7 +18,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-CountryOfIssue.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-CountryOfIssue.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A country acting as an assuing authority for a document.",
   "value": {
-    "fqn": "shr.core.Country",
+    "fqn": "obf.datatype.Country",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-DateOfBirth.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-DateOfBirth.json
@@ -28,7 +28,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Device.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Device.json
@@ -17,7 +17,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -25,7 +25,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/entity/vs/DeviceVS",
               "bindingStrength": "REQUIRED",
@@ -87,7 +87,7 @@
       }
     },
     {
-      "fqn": "shr.core.Version",
+      "fqn": "obf.datatype.Version",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-DoseForm.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-DoseForm.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-DriversLicenseNumber.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-DriversLicenseNumber.json
@@ -24,7 +24,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Ethnicity.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Ethnicity.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-EthnicityDetail.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-EthnicityDetail.json
@@ -14,7 +14,7 @@
     },
     "options": [
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue",
         "constraints": {
           "valueSet": {
@@ -25,7 +25,7 @@
         }
       },
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue",
         "constraints": {
           "valueSet": {

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Facility.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Facility.json
@@ -31,7 +31,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -39,7 +39,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/v3-ServiceDeliveryLocationRoleType",
               "bindingStrength": "REQUIRED",
@@ -78,7 +78,7 @@
       }
     },
     {
-      "fqn": "shr.core.ContactPoint",
+      "fqn": "obf.datatype.ContactPoint",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-FathersName.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-FathersName.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The name of the father as it was or likely to have been recorded on the birth certificate of the subject; most likely the name of the father at the time of birth of the subject.",
   "value": {
-    "fqn": "shr.core.HumanName",
+    "fqn": "obf.datatype.HumanName",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-FictionalPersonFlag.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-FictionalPersonFlag.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,7 +21,7 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/YesNoVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/YesNoVS",
         "bindingStrength": "REQUIRED",
         "lastModifiedBy": "cimi.entity.FictionalPersonFlag"
       }

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Group.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Group.json
@@ -30,7 +30,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -38,7 +38,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/group-type",
               "bindingStrength": "REQUIRED",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "fqn": "shr.core.Title",
+      "fqn": "obf.datatype.Title",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -91,7 +91,7 @@
       }
     },
     {
-      "fqn": "shr.core.Count",
+      "fqn": "obf.datatype.Count",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-GroupCharacteristic.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-GroupCharacteristic.json
@@ -24,11 +24,11 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Quantity",
+        "fqn": "obf.datatype.Quantity",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Range",
+        "fqn": "obf.datatype.Range",
         "valueType": "IdentifiableValue"
       }
     ]
@@ -51,7 +51,7 @@
       }
     },
     {
-      "fqn": "shr.core.TimePeriod",
+      "fqn": "obf.datatype.TimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-GroupCharacteristicCode.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-GroupCharacteristicCode.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A code describing the characteristic present, absent, or having a value in this group.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-HandlingRisk.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-HandlingRisk.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Cautions on the handling of this specimen.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Headshot.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Headshot.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A photograph showing a person's face.",
   "value": {
-    "fqn": "shr.core.Attachment",
+    "fqn": "obf.datatype.Attachment",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Ingredient.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Ingredient.json
@@ -20,7 +20,7 @@
     },
     "options": [
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       },
       {

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-IngredientAmount.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-IngredientAmount.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The amount of an ingredient in a mixture, as a ratio. For example, 250 mg per tablet is expressed as a ratio where the numerator is 250mg and the denominator is 1 tablet.",
   "value": {
-    "fqn": "shr.core.Ratio",
+    "fqn": "obf.datatype.Ratio",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-LanguageQualifier.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-LanguageQualifier.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Additional information about a person's use of language.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-LanguageUsed.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-LanguageUsed.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Language used for communication by a human, either the subject of record, parent, or other involved person.",
   "value": {
-    "fqn": "shr.core.Language",
+    "fqn": "obf.datatype.Language",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Location.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Location.json
@@ -29,15 +29,15 @@
     },
     "options": [
       {
-        "fqn": "shr.core.Address",
+        "fqn": "obf.datatype.Address",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Geoposition",
+        "fqn": "obf.datatype.Geoposition",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.GeopoliticalLocation",
+        "fqn": "obf.datatype.GeopoliticalLocation",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-MaritalStatus.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-MaritalStatus.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-MedicalInterpreterNeeded.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-MedicalInterpreterNeeded.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,7 +21,7 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/YesNoUnknownVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/YesNoUnknownVS",
         "bindingStrength": "REQUIRED",
         "lastModifiedBy": "cimi.entity.MedicalInterpreterNeeded"
       }
@@ -29,7 +29,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Language",
+      "fqn": "obf.datatype.Language",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Medication.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Medication.json
@@ -23,7 +23,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -31,7 +31,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes",
               "bindingStrength": "EXTENSIBLE",
@@ -117,7 +117,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/medication-package-form",
               "bindingStrength": "EXAMPLE",

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-MedicationIngredient.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-MedicationIngredient.json
@@ -20,7 +20,7 @@
     },
     "options": [
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       },
       {

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-MothersMaidenName.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-MothersMaidenName.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.HumanName",
+    "fqn": "obf.datatype.HumanName",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-NationalProviderIdentifier.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-NationalProviderIdentifier.json
@@ -32,7 +32,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -40,7 +40,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/identifier-use",
               "bindingStrength": "REQUIRED",
@@ -67,7 +67,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -75,7 +75,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/identifier-type",
               "bindingStrength": "EXTENSIBLE",
@@ -102,7 +102,7 @@
       }
     },
     {
-      "fqn": "shr.core.CodeSystem",
+      "fqn": "obf.datatype.CodeSystem",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Organization.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Organization.json
@@ -45,7 +45,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -53,7 +53,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/organization-type",
               "bindingStrength": "REQUIRED",
@@ -76,14 +76,14 @@
       }
     },
     {
-      "fqn": "shr.core.Address",
+      "fqn": "obf.datatype.Address",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1
       }
     },
     {
-      "fqn": "shr.core.ContactPoint",
+      "fqn": "obf.datatype.ContactPoint",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-OrganizationIdentifier.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-OrganizationIdentifier.json
@@ -26,7 +26,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -34,7 +34,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/identifier-use",
               "bindingStrength": "REQUIRED",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -69,7 +69,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/identifier-type",
               "bindingStrength": "EXTENSIBLE",
@@ -96,7 +96,7 @@
       }
     },
     {
-      "fqn": "shr.core.CodeSystem",
+      "fqn": "obf.datatype.CodeSystem",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Package.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Package.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The kind of container the medication comes in.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-PassportNumber.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-PassportNumber.json
@@ -30,7 +30,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Person.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Person.json
@@ -23,7 +23,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.HumanName",
+      "fqn": "obf.datatype.HumanName",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1
@@ -62,7 +62,7 @@
       }
     },
     {
-      "fqn": "shr.core.Address",
+      "fqn": "obf.datatype.Address",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0
@@ -77,7 +77,7 @@
       }
     },
     {
-      "fqn": "shr.core.ContactPoint",
+      "fqn": "obf.datatype.ContactPoint",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-PlaceOfBirth.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-PlaceOfBirth.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.GeopoliticalLocation",
+    "fqn": "obf.datatype.GeopoliticalLocation",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Practitioner.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Practitioner.json
@@ -31,7 +31,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.HumanName": {
+          "obf.datatype.HumanName": {
             "card": {
               "min": 1,
               "max": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Qualification.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Qualification.json
@@ -14,7 +14,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -22,7 +22,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
               "bindingStrength": "REQUIRED",
@@ -33,7 +33,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Race.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Race.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-RaceDetail.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-RaceDetail.json
@@ -14,7 +14,7 @@
     },
     "options": [
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue",
         "constraints": {
           "valueSet": {
@@ -25,7 +25,7 @@
         }
       },
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue",
         "constraints": {
           "valueSet": {

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-RelatedPerson.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-RelatedPerson.json
@@ -33,7 +33,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-RelationshipType.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-RelationshipType.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-SequenceNumber.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-SequenceNumber.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The sequence number for this specimen in a collection of specimens.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-SpecialHandling.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-SpecialHandling.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Information about the proper handling of the specimen.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Specimen.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Specimen.json
@@ -33,7 +33,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/specimen-status",
               "bindingStrength": "REQUIRED",
@@ -56,7 +56,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -64,7 +64,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/v2-0487",
               "bindingStrength": "REQUIRED",
@@ -126,7 +126,7 @@
       }
     },
     {
-      "fqn": "shr.core.ReceivedTime",
+      "fqn": "obf.datatype.ReceivedTime",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-SpecimenContainer.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-SpecimenContainer.json
@@ -17,7 +17,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -33,7 +33,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-SpecimenQuantity.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-SpecimenQuantity.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Quantity of specimen within container.",
   "value": {
-    "fqn": "shr.core.SimpleQuantity",
+    "fqn": "obf.datatype.SimpleQuantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-SpecimenStatus.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-SpecimenStatus.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-SpokenLanguageProficiency.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-SpokenLanguageProficiency.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,7 +21,7 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/PerformanceGradingScaleVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/PerformanceGradingScaleVS",
         "bindingStrength": "REQUIRED",
         "lastModifiedBy": "cimi.entity.SpokenLanguageProficiency"
       }

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-StateOfIssue.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-StateOfIssue.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A state or country acting as an assuing authority for a document.",
   "value": {
-    "fqn": "shr.core.State",
+    "fqn": "obf.datatype.State",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-Substance.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-Substance.json
@@ -23,7 +23,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -31,7 +31,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/substance-code",
               "bindingStrength": "PREFERRED",
@@ -54,14 +54,14 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/substance-category",
               "bindingStrength": "EXTENSIBLE",
@@ -92,7 +92,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/substance-status",
               "bindingStrength": "REQUIRED",
@@ -115,7 +115,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-entity/cimi-entity-WrittenLanguageProficiency.json
+++ b/test/fixtures/cimcore/cimi-entity/cimi-entity-WrittenLanguageProficiency.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,7 +21,7 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/PerformanceGradingScaleVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/PerformanceGradingScaleVS",
         "bindingStrength": "REQUIRED",
         "lastModifiedBy": "cimi.entity.WrittenLanguageProficiency"
       }

--- a/test/fixtures/cimcore/cimi-entity/mappings/AccessionIdentifier-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/AccessionIdentifier-mapping.json
@@ -20,28 +20,28 @@
       },
       {
         "sourcePath": [
-          "shr.core.Purpose"
+          "obf.datatype.Purpose"
         ],
         "target": "use",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.CodeSystem"
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
         "lastModifiedBy": "cimi.element.Identifier"

--- a/test/fixtures/cimcore/cimi-entity/mappings/Device-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/Device-mapping.json
@@ -9,7 +9,7 @@
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.entity.Device"
@@ -51,7 +51,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Version"
+          "obf.datatype.Version"
         ],
         "target": "version",
         "lastModifiedBy": "cimi.entity.Device"

--- a/test/fixtures/cimcore/cimi-entity/mappings/Facility-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/Facility-mapping.json
@@ -17,7 +17,7 @@
       {
         "sourcePath": [
           "cimi.entity.Location",
-          "shr.core.Address"
+          "obf.datatype.Address"
         ],
         "target": "address",
         "lastModifiedBy": "cimi.entity.Facility"
@@ -25,8 +25,8 @@
       {
         "sourcePath": [
           "cimi.entity.Location",
-          "shr.core.Geoposition",
-          "shr.core.Latitude"
+          "obf.datatype.Geoposition",
+          "obf.datatype.Latitude"
         ],
         "target": "position.latitude",
         "lastModifiedBy": "cimi.entity.Facility"
@@ -34,8 +34,8 @@
       {
         "sourcePath": [
           "cimi.entity.Location",
-          "shr.core.Geoposition",
-          "shr.core.Longitude"
+          "obf.datatype.Geoposition",
+          "obf.datatype.Longitude"
         ],
         "target": "position.longitude",
         "lastModifiedBy": "cimi.entity.Facility"
@@ -43,15 +43,15 @@
       {
         "sourcePath": [
           "cimi.entity.Location",
-          "shr.core.Geoposition",
-          "shr.core.Altitude"
+          "obf.datatype.Geoposition",
+          "obf.datatype.Altitude"
         ],
         "target": "position.altitude",
         "lastModifiedBy": "cimi.entity.Facility"
       },
       {
         "sourcePath": [
-          "shr.core.ContactPoint"
+          "obf.datatype.ContactPoint"
         ],
         "target": "telecom",
         "lastModifiedBy": "cimi.entity.Facility"
@@ -65,7 +65,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.entity.Facility"

--- a/test/fixtures/cimcore/cimi-entity/mappings/Group-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/Group-mapping.json
@@ -16,7 +16,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.entity.Group"
@@ -30,7 +30,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Title"
+          "obf.datatype.Title"
         ],
         "target": "name",
         "lastModifiedBy": "cimi.entity.Group"
@@ -61,7 +61,7 @@
       {
         "sourcePath": [
           "cimi.entity.GroupCharacteristic",
-          "shr.core.TimePeriod"
+          "obf.datatype.TimePeriod"
         ],
         "target": "characteristic.period",
         "lastModifiedBy": "cimi.entity.Group"
@@ -124,7 +124,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Count"
+          "obf.datatype.Count"
         ],
         "target": "quantity",
         "lastModifiedBy": "cimi.entity.Group"

--- a/test/fixtures/cimcore/cimi-entity/mappings/Medication-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/Medication-mapping.json
@@ -9,7 +9,7 @@
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "code",
         "lastModifiedBy": "cimi.entity.Medication"
@@ -24,7 +24,7 @@
       {
         "sourcePath": [
           "cimi.entity.MedicationIngredient",
-          "shr.core.CodeableConcept"
+          "obf.datatype.CodeableConcept"
         ],
         "target": "ingredient.item[x]",
         "lastModifiedBy": "cimi.entity.Medication"

--- a/test/fixtures/cimcore/cimi-entity/mappings/NationalProviderIdentifier-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/NationalProviderIdentifier-mapping.json
@@ -20,28 +20,28 @@
       },
       {
         "sourcePath": [
-          "shr.core.Purpose"
+          "obf.datatype.Purpose"
         ],
         "target": "use",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.CodeSystem"
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
         "lastModifiedBy": "cimi.element.Identifier"

--- a/test/fixtures/cimcore/cimi-entity/mappings/Organization-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/Organization-mapping.json
@@ -23,7 +23,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.entity.Organization"
@@ -37,14 +37,14 @@
       },
       {
         "sourcePath": [
-          "shr.core.Address"
+          "obf.datatype.Address"
         ],
         "target": "address",
         "lastModifiedBy": "cimi.entity.Organization"
       },
       {
         "sourcePath": [
-          "shr.core.ContactPoint"
+          "obf.datatype.ContactPoint"
         ],
         "target": "contact",
         "lastModifiedBy": "cimi.entity.Organization"

--- a/test/fixtures/cimcore/cimi-entity/mappings/OrganizationIdentifier-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/OrganizationIdentifier-mapping.json
@@ -20,28 +20,28 @@
       },
       {
         "sourcePath": [
-          "shr.core.Purpose"
+          "obf.datatype.Purpose"
         ],
         "target": "use",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.CodeSystem"
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
         "lastModifiedBy": "cimi.element.Identifier"
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
         "lastModifiedBy": "cimi.element.Identifier"

--- a/test/fixtures/cimcore/cimi-entity/mappings/Patient-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/Patient-mapping.json
@@ -18,7 +18,7 @@
       {
         "sourcePath": [
           "cimi.entity.Person",
-          "shr.core.HumanName"
+          "obf.datatype.HumanName"
         ],
         "target": "name",
         "lastModifiedBy": "cimi.entity.Patient"
@@ -42,7 +42,7 @@
       {
         "sourcePath": [
           "cimi.entity.Person",
-          "shr.core.Address"
+          "obf.datatype.Address"
         ],
         "target": "address",
         "lastModifiedBy": "cimi.entity.Patient"
@@ -50,7 +50,7 @@
       {
         "sourcePath": [
           "cimi.entity.Person",
-          "shr.core.ContactPoint"
+          "obf.datatype.ContactPoint"
         ],
         "target": "telecom",
         "lastModifiedBy": "cimi.entity.Patient"

--- a/test/fixtures/cimcore/cimi-entity/mappings/Practitioner-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/Practitioner-mapping.json
@@ -18,7 +18,7 @@
       {
         "sourcePath": [
           "cimi.entity.Person",
-          "shr.core.HumanName"
+          "obf.datatype.HumanName"
         ],
         "target": "name",
         "lastModifiedBy": "cimi.entity.Practitioner"
@@ -42,7 +42,7 @@
       {
         "sourcePath": [
           "cimi.entity.Person",
-          "shr.core.Address"
+          "obf.datatype.Address"
         ],
         "target": "address",
         "lastModifiedBy": "cimi.entity.Practitioner"
@@ -50,7 +50,7 @@
       {
         "sourcePath": [
           "cimi.entity.Person",
-          "shr.core.ContactPoint"
+          "obf.datatype.ContactPoint"
         ],
         "target": "telecom",
         "lastModifiedBy": "cimi.entity.Practitioner"
@@ -80,7 +80,7 @@
       {
         "sourcePath": [
           "cimi.entity.Qualification",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "qualification.code",
         "lastModifiedBy": "cimi.entity.Practitioner"
@@ -88,7 +88,7 @@
       {
         "sourcePath": [
           "cimi.entity.Qualification",
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "qualification.period",
         "lastModifiedBy": "cimi.entity.Practitioner"

--- a/test/fixtures/cimcore/cimi-entity/mappings/RelatedPerson-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/RelatedPerson-mapping.json
@@ -18,7 +18,7 @@
       {
         "sourcePath": [
           "cimi.entity.Person",
-          "shr.core.HumanName"
+          "obf.datatype.HumanName"
         ],
         "target": "name",
         "lastModifiedBy": "cimi.entity.RelatedPerson"
@@ -42,7 +42,7 @@
       {
         "sourcePath": [
           "cimi.entity.Person",
-          "shr.core.Address"
+          "obf.datatype.Address"
         ],
         "target": "address",
         "lastModifiedBy": "cimi.entity.RelatedPerson"
@@ -58,7 +58,7 @@
       {
         "sourcePath": [
           "cimi.entity.Person",
-          "shr.core.ContactPoint"
+          "obf.datatype.ContactPoint"
         ],
         "target": "telecom",
         "lastModifiedBy": "cimi.entity.RelatedPerson"
@@ -72,7 +72,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
         "lastModifiedBy": "cimi.entity.RelatedPerson"

--- a/test/fixtures/cimcore/cimi-entity/mappings/Specimen-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/Specimen-mapping.json
@@ -23,7 +23,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.entity.Specimen"
@@ -44,7 +44,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.ReceivedTime"
+          "obf.datatype.ReceivedTime"
         ],
         "target": "receivedTime",
         "lastModifiedBy": "cimi.entity.Specimen"
@@ -60,7 +60,7 @@
       {
         "sourcePath": [
           "cimi.entity.SpecimenContainer",
-          "shr.core.Details"
+          "obf.datatype.Details"
         ],
         "target": "container.description",
         "lastModifiedBy": "cimi.entity.Specimen"
@@ -68,7 +68,7 @@
       {
         "sourcePath": [
           "cimi.entity.SpecimenContainer",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "container.type",
         "lastModifiedBy": "cimi.entity.Specimen"

--- a/test/fixtures/cimcore/cimi-entity/mappings/Substance-mapping.json
+++ b/test/fixtures/cimcore/cimi-entity/mappings/Substance-mapping.json
@@ -9,7 +9,7 @@
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "code",
         "lastModifiedBy": "cimi.entity.Substance"
@@ -32,7 +32,7 @@
       {
         "sourcePath": [
           "cimi.entity.Ingredient",
-          "shr.core.CodeableConcept"
+          "obf.datatype.CodeableConcept"
         ],
         "target": "ingredient.substance[x]",
         "lastModifiedBy": "cimi.entity.Substance"

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-AdditionalDoseInstruction.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-AdditionalDoseInstruction.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-AdministrationMethod.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-AdministrationMethod.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-AsNeededIndicator.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-AsNeededIndicator.json
@@ -24,7 +24,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue",
         "constraints": {
           "valueSet": {

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-Dosage.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-Dosage.json
@@ -53,7 +53,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/additional-instruction-codes",
               "bindingStrength": "REQUIRED",
@@ -80,7 +80,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/administration-method-codes",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-DoseAmount.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-DoseAmount.json
@@ -14,11 +14,11 @@
     },
     "options": [
       {
-        "fqn": "shr.core.SimpleQuantity",
+        "fqn": "obf.datatype.SimpleQuantity",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Range",
+        "fqn": "obf.datatype.Range",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MaximumDosePerTimePeriod.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MaximumDosePerTimePeriod.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The maximum amount of a medication to be taken in a given period of time (e.g., no more than x in any 24-hour period)",
   "value": {
-    "fqn": "shr.core.Ratio",
+    "fqn": "obf.datatype.Ratio",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationAdherenceStatement.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationAdherenceStatement.json
@@ -141,7 +141,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -241,14 +241,14 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "cimi.statement.CodedEvaluationResultRecorded"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
-                  "uri": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                  "uri": "http://standardhealthrecord.org/obf/datatype/vs/QualitativeFrequencyVS",
                   "bindingStrength": "REQUIRED",
                   "lastModifiedBy": "cimi.medication.MedicationAdherenceStatement"
                 }
@@ -265,7 +265,7 @@
         "valueSet": [
           {
             "constraint": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/QualitativeFrequencyVS",
               "bindingStrength": "REQUIRED",
               "lastModifiedBy": "cimi.medication.MedicationAdherenceStatement"
             },
@@ -282,7 +282,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.statement.CodedEvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationChangeStatement.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationChangeStatement.json
@@ -163,7 +163,7 @@
         "subpaths": {
           "cimi.context.Reason": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/cimi/medication/vs/MedicationChangeReasonVS",
                   "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationChangeTopic.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationChangeTopic.json
@@ -28,7 +28,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -40,7 +40,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -48,7 +48,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/medication/vs/MedicationChangeTypeVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationDispenseRequestedStatement.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationDispenseRequestedStatement.json
@@ -166,9 +166,9 @@
               }
             }
           },
-          "shr.core.PriorityRank": {
+          "obf.datatype.PriorityRank": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://hl7.org/fhir/ValueSet/medication-request-priority",
                   "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationDispenseTopic.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationDispenseTopic.json
@@ -30,7 +30,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationNonAdherenceReason.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationNonAdherenceReason.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Reason that patient did not adhere to a medication regimen.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationNotPrescribedStatement.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationNotPrescribedStatement.json
@@ -157,7 +157,7 @@
         "subpaths": {
           "cimi.context.Reason": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/cimi/medication/vs/MedicationNotUsedReasonVS",
                   "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationNotUsedStatement.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationNotUsedStatement.json
@@ -147,14 +147,14 @@
           "lastModifiedBy": "cimi.medication.MedicationNotUsedStatement"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "card": {
               "min": 0,
               "max": 1,
               "lastModifiedBy": "cimi.medication.MedicationNotUsedStatement"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://hl7.org/fhir/ValueSet/medication-statement-category",
                   "bindingStrength": "PREFERRED",
@@ -233,7 +233,7 @@
         "subpaths": {
           "cimi.context.Reason": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/cimi/medication/vs/MedicationNotUsedReasonVS",
                   "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationTopic.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationTopic.json
@@ -29,7 +29,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationUseTopic.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationUseTopic.json
@@ -30,7 +30,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationUsedStatement.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-MedicationUsedStatement.json
@@ -147,14 +147,14 @@
           "lastModifiedBy": "cimi.medication.MedicationUsedStatement"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "card": {
               "min": 0,
               "max": 1,
               "lastModifiedBy": "cimi.medication.MedicationUsedStatement"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://hl7.org/fhir/ValueSet/medication-statement-category",
                   "bindingStrength": "PREFERRED",

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-QuantityPerDispense.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-QuantityPerDispense.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The amount that is to be dispensed for one fill.",
   "value": {
-    "fqn": "shr.core.SimpleQuantity",
+    "fqn": "obf.datatype.SimpleQuantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-SupplyDuration.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-SupplyDuration.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Identifies the period time over which the supplied product is expected to be used, or the length of time the dispense is expected to last.",
   "value": {
-    "fqn": "shr.core.Duration",
+    "fqn": "obf.datatype.Duration",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-medication/cimi-medication-TimingOfDoses.json
+++ b/test/fixtures/cimcore/cimi-medication/cimi-medication-TimingOfDoses.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "When doses of medication should be administered.",
   "value": {
-    "fqn": "shr.core.Timing",
+    "fqn": "obf.datatype.Timing",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-medication/mappings/MedicationAdherenceStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-medication/mappings/MedicationAdherenceStatement-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-medication/mappings/MedicationDispenseRequestedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-medication/mappings/MedicationDispenseRequestedStatement-mapping.json
@@ -74,7 +74,7 @@
       {
         "sourcePath": [
           "cimi.context.RequestedContext",
-          "shr.core.PriorityRank"
+          "obf.datatype.PriorityRank"
         ],
         "target": "priority",
         "lastModifiedBy": "cimi.medication.MedicationDispenseRequestedStatement"

--- a/test/fixtures/cimcore/cimi-medication/mappings/MedicationNotUsedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-medication/mappings/MedicationNotUsedStatement-mapping.json
@@ -18,7 +18,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "dateAsserted",
         "lastModifiedBy": "cimi.medication.MedicationNotUsedStatement"
@@ -34,7 +34,7 @@
       {
         "sourcePath": [
           "cimi.medication.MedicationUseTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.medication.MedicationNotUsedStatement"
@@ -50,7 +50,7 @@
       {
         "sourcePath": [
           "cimi.context.NotPerformedContext",
-          "shr.core.NonOccurrenceTimeOrPeriod"
+          "obf.datatype.NonOccurrenceTimeOrPeriod"
         ],
         "target": "effective[x]",
         "lastModifiedBy": "cimi.medication.MedicationNotUsedStatement"

--- a/test/fixtures/cimcore/cimi-medication/mappings/MedicationUsedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-medication/mappings/MedicationUsedStatement-mapping.json
@@ -18,7 +18,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "dateAsserted  // date asserted and date recorded may not be the same",
         "lastModifiedBy": "cimi.medication.MedicationUsedStatement"
@@ -42,7 +42,7 @@
       {
         "sourcePath": [
           "cimi.medication.MedicationUseTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.medication.MedicationUsedStatement"
@@ -58,7 +58,7 @@
       {
         "sourcePath": [
           "cimi.context.PerformedContext",
-          "shr.core.OccurrenceTimeOrPeriod"
+          "obf.datatype.OccurrenceTimeOrPeriod"
         ],
         "target": "effective[x]",
         "lastModifiedBy": "cimi.medication.MedicationUsedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-Access.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-Access.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The route used to access the site of a procedure. It is used to distinguish open, closed, and percutaneous procedures.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-AmountOrSize.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-AmountOrSize.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The quantity of specimen collected",
   "value": {
-    "fqn": "shr.core.SimpleQuantity",
+    "fqn": "obf.datatype.SimpleQuantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-DirectSiteCode.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-DirectSiteCode.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The site where the procedure is performed.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ImagingProcedureTopic.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ImagingProcedureTopic.json
@@ -26,7 +26,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code",
               "bindingStrength": "EXTENSIBLE",
@@ -52,7 +52,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ImagingSubstance.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ImagingSubstance.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Substance used for this imaging procedure such as a contrast agent.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-Indication.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-Indication.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Conditions or situations where the procedure is recommended. In the Performed context, the actual indication should be reported.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-IndirectDeviceCode.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-IndirectDeviceCode.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "An indirect device used for this procedure.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-IndirectSiteCode.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-IndirectSiteCode.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The indirect site for this procedure.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-LaboratoryProcedureTopic.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-LaboratoryProcedureTopic.json
@@ -32,7 +32,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/observation-codes",
               "bindingStrength": "REQUIRED",
@@ -66,7 +66,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -74,7 +74,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ProcedureNotPerformedContext.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ProcedureNotPerformedContext.json
@@ -76,7 +76,7 @@
       }
     },
     {
-      "fqn": "shr.core.NonOccurrenceTimeOrPeriod",
+      "fqn": "obf.datatype.NonOccurrenceTimeOrPeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ProcedurePerformedContext.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ProcedurePerformedContext.json
@@ -41,7 +41,7 @@
       }
     },
     {
-      "fqn": "shr.core.OccurrenceTimeOrPeriod",
+      "fqn": "obf.datatype.OccurrenceTimeOrPeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ProcedureRequestedContext.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ProcedureRequestedContext.json
@@ -155,7 +155,7 @@
       }
     },
     {
-      "fqn": "shr.core.PriorityRank",
+      "fqn": "obf.datatype.PriorityRank",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -163,7 +163,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/request-priority",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ProcedureTopic.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-ProcedureTopic.json
@@ -25,7 +25,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code",
               "bindingStrength": "EXTENSIBLE",
@@ -52,7 +52,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-SpecimenCollectionTopic.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-SpecimenCollectionTopic.json
@@ -26,7 +26,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code",
               "bindingStrength": "EXTENSIBLE",
@@ -52,7 +52,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-SurgicalApproach.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-SurgicalApproach.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The technique used to reach the site of the procedure. Approaches may be through the skin or mucous membrane, through an orifice or external.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-SurgicalProcedureTopic.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-SurgicalProcedureTopic.json
@@ -26,7 +26,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code",
               "bindingStrength": "EXTENSIBLE",
@@ -52,7 +52,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-UsingAccessDeviceCode.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-UsingAccessDeviceCode.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The access device used to perform the procedure.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/cimi-procedure-UsingDeviceCode.json
+++ b/test/fixtures/cimcore/cimi-procedure/cimi-procedure-UsingDeviceCode.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The device used to perform the procedure.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-procedure/mappings/ImagingProcedurePerformedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/ImagingProcedurePerformedStatement-mapping.json
@@ -29,7 +29,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ImagingProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"
@@ -77,7 +77,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedurePerformedContext",
-          "shr.core.OccurrenceTimeOrPeriod"
+          "obf.datatype.OccurrenceTimeOrPeriod"
         ],
         "target": "performed[x]",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/ImagingProcedureRequestedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/ImagingProcedureRequestedStatement-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "authoredOn",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -39,7 +39,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ImagingProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -118,7 +118,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedureRequestedContext",
-          "shr.core.PriorityRank"
+          "obf.datatype.PriorityRank"
         ],
         "target": "priority",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/LaboratoryProcedurePerformedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/LaboratoryProcedurePerformedStatement-mapping.json
@@ -29,7 +29,7 @@
       {
         "sourcePath": [
           "cimi.procedure.LaboratoryProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"
@@ -77,7 +77,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedurePerformedContext",
-          "shr.core.OccurrenceTimeOrPeriod"
+          "obf.datatype.OccurrenceTimeOrPeriod"
         ],
         "target": "performed[x]",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/LaboratoryProcedureRequestedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/LaboratoryProcedureRequestedStatement-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "authoredOn",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -39,7 +39,7 @@
       {
         "sourcePath": [
           "cimi.procedure.LaboratoryProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -118,7 +118,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedureRequestedContext",
-          "shr.core.PriorityRank"
+          "obf.datatype.PriorityRank"
         ],
         "target": "priority",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/ProcedureNotPerformedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/ProcedureNotPerformedStatement-mapping.json
@@ -25,7 +25,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedureNotPerformedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/ProcedurePerformedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/ProcedurePerformedStatement-mapping.json
@@ -25,7 +25,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"
@@ -73,7 +73,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedurePerformedContext",
-          "shr.core.OccurrenceTimeOrPeriod"
+          "obf.datatype.OccurrenceTimeOrPeriod"
         ],
         "target": "performed[x]",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/ProcedureRequestedAgainstStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/ProcedureRequestedAgainstStatement-mapping.json
@@ -10,7 +10,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "authoredOn",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedAgainstStatement"
@@ -35,7 +35,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedAgainstStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/ProcedureRequestedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/ProcedureRequestedStatement-mapping.json
@@ -10,7 +10,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "authoredOn",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -35,7 +35,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -114,7 +114,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedureRequestedContext",
-          "shr.core.PriorityRank"
+          "obf.datatype.PriorityRank"
         ],
         "target": "priority",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/SpecimenCollectionPerformedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/SpecimenCollectionPerformedStatement-mapping.json
@@ -29,7 +29,7 @@
       {
         "sourcePath": [
           "cimi.procedure.SpecimenCollectionTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"
@@ -77,7 +77,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedurePerformedContext",
-          "shr.core.OccurrenceTimeOrPeriod"
+          "obf.datatype.OccurrenceTimeOrPeriod"
         ],
         "target": "performed[x]",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/SpecimenCollectionRequestedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/SpecimenCollectionRequestedStatement-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "authoredOn",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -39,7 +39,7 @@
       {
         "sourcePath": [
           "cimi.procedure.SpecimenCollectionTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -118,7 +118,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedureRequestedContext",
-          "shr.core.PriorityRank"
+          "obf.datatype.PriorityRank"
         ],
         "target": "priority",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/SurgicalProcedureNotPerformedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/SurgicalProcedureNotPerformedStatement-mapping.json
@@ -29,7 +29,7 @@
       {
         "sourcePath": [
           "cimi.procedure.SurgicalProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedureNotPerformedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/SurgicalProcedurePerformedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/SurgicalProcedurePerformedStatement-mapping.json
@@ -29,7 +29,7 @@
       {
         "sourcePath": [
           "cimi.procedure.SurgicalProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"
@@ -77,7 +77,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedurePerformedContext",
-          "shr.core.OccurrenceTimeOrPeriod"
+          "obf.datatype.OccurrenceTimeOrPeriod"
         ],
         "target": "performed[x]",
         "lastModifiedBy": "cimi.procedure.ProcedurePerformedStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/SurgicalProcedureRequestedAgainstStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/SurgicalProcedureRequestedAgainstStatement-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "authoredOn",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedAgainstStatement"
@@ -39,7 +39,7 @@
       {
         "sourcePath": [
           "cimi.procedure.SurgicalProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedAgainstStatement"

--- a/test/fixtures/cimcore/cimi-procedure/mappings/SurgicalProcedureRequestedStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-procedure/mappings/SurgicalProcedureRequestedStatement-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "authoredOn",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -39,7 +39,7 @@
       {
         "sourcePath": [
           "cimi.procedure.SurgicalProcedureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"
@@ -118,7 +118,7 @@
       {
         "sourcePath": [
           "cimi.procedure.ProcedureRequestedContext",
-          "shr.core.PriorityRank"
+          "obf.datatype.PriorityRank"
         ],
         "target": "priority",
         "lastModifiedBy": "cimi.procedure.ProcedureRequestedStatement"

--- a/test/fixtures/cimcore/cimi-statement/cimi-statement-ClinicalNote.json
+++ b/test/fixtures/cimcore/cimi-statement/cimi-statement-ClinicalNote.json
@@ -131,7 +131,7 @@
           "lastModifiedBy": "cimi.statement.ClinicalNote"
         },
         "subpaths": {
-          "shr.core.Details": {
+          "obf.datatype.Details": {
             "card": {
               "min": 1,
               "max": 1,

--- a/test/fixtures/cimcore/cimi-statement/cimi-statement-CodedEvaluationResultRecorded.json
+++ b/test/fixtures/cimcore/cimi-statement/cimi-statement-CodedEvaluationResultRecorded.json
@@ -176,7 +176,7 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "cimi.statement.CodedEvaluationResultRecorded"
             }
@@ -198,7 +198,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "cimi.statement.CodedEvaluationResultRecorded"
             },

--- a/test/fixtures/cimcore/cimi-statement/cimi-statement-DiagnosticService.json
+++ b/test/fixtures/cimcore/cimi-statement/cimi-statement-DiagnosticService.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-statement/cimi-statement-LaboratoryTestResultRecorded.json
+++ b/test/fixtures/cimcore/cimi-statement/cimi-statement-LaboratoryTestResultRecorded.json
@@ -125,9 +125,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {

--- a/test/fixtures/cimcore/cimi-statement/cimi-statement-NonLabCodedEvaluationResultRecorded.json
+++ b/test/fixtures/cimcore/cimi-statement/cimi-statement-NonLabCodedEvaluationResultRecorded.json
@@ -206,7 +206,7 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "cimi.statement.CodedEvaluationResultRecorded"
             }
@@ -228,7 +228,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.statement.CodedEvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-statement/cimi-statement-PanelRecorded.json
+++ b/test/fixtures/cimcore/cimi-statement/cimi-statement-PanelRecorded.json
@@ -120,9 +120,9 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {

--- a/test/fixtures/cimcore/cimi-statement/cimi-statement-SimplifiedLaboratoryTestResultRecorded.json
+++ b/test/fixtures/cimcore/cimi-statement/cimi-statement-SimplifiedLaboratoryTestResultRecorded.json
@@ -126,9 +126,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {

--- a/test/fixtures/cimcore/cimi-statement/mappings/CodedEvaluationResultRecorded-mapping.json
+++ b/test/fixtures/cimcore/cimi-statement/mappings/CodedEvaluationResultRecorded-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-statement/mappings/ConditionPresenceStatement-mapping.json
+++ b/test/fixtures/cimcore/cimi-statement/mappings/ConditionPresenceStatement-mapping.json
@@ -10,7 +10,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "assertedDate",
         "lastModifiedBy": "cimi.statement.ConditionPresenceStatement"
@@ -33,7 +33,7 @@
       {
         "sourcePath": [
           "cimi.topic.ConditionTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.ConditionPresenceStatement"
@@ -114,7 +114,7 @@
         "sourcePath": [
           "cimi.context.ConditionPresenceContext",
           "cimi.context.Stage",
-          "shr.core.CodeableConcept"
+          "obf.datatype.CodeableConcept"
         ],
         "target": "stage.summary",
         "lastModifiedBy": "cimi.statement.ConditionPresenceStatement"

--- a/test/fixtures/cimcore/cimi-statement/mappings/EvaluationResultRecorded-mapping.json
+++ b/test/fixtures/cimcore/cimi-statement/mappings/EvaluationResultRecorded-mapping.json
@@ -10,7 +10,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -99,8 +99,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -109,8 +109,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -119,7 +119,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-statement/mappings/LaboratoryTestResultRecorded-mapping.json
+++ b/test/fixtures/cimcore/cimi-statement/mappings/LaboratoryTestResultRecorded-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-statement/mappings/NonLabCodedEvaluationResultRecorded-mapping.json
+++ b/test/fixtures/cimcore/cimi-statement/mappings/NonLabCodedEvaluationResultRecorded-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-statement/mappings/NonLabPanelRecorded-mapping.json
+++ b/test/fixtures/cimcore/cimi-statement/mappings/NonLabPanelRecorded-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.PanelTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-statement/mappings/PanelRecorded-mapping.json
+++ b/test/fixtures/cimcore/cimi-statement/mappings/PanelRecorded-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.PanelTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-statement/mappings/SimplifiedLaboratoryTestResultRecorded-mapping.json
+++ b/test/fixtures/cimcore/cimi-statement/mappings/SimplifiedLaboratoryTestResultRecorded-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-ActionTopic.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-ActionTopic.json
@@ -28,7 +28,7 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-ApplicableAgeRange.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-ApplicableAgeRange.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
   "value": {
-    "fqn": "shr.core.Range",
+    "fqn": "obf.datatype.Range",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-ApplicableSubpopulation.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-ApplicableSubpopulation.json
@@ -14,7 +14,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-AssertionTopic.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-AssertionTopic.json
@@ -41,7 +41,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-CodedEvaluationComponent.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-CodedEvaluationComponent.json
@@ -22,7 +22,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -35,7 +35,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
             },

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-ComponentResultValue.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-ComponentResultValue.json
@@ -14,11 +14,11 @@
     },
     "options": [
       {
-        "fqn": "shr.core.Quantity",
+        "fqn": "obf.datatype.Quantity",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       },
       {
@@ -26,15 +26,15 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Range",
+        "fqn": "obf.datatype.Range",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Ratio",
+        "fqn": "obf.datatype.Ratio",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.Attachment",
+        "fqn": "obf.datatype.Attachment",
         "valueType": "IdentifiableValue"
       },
       {
@@ -46,11 +46,11 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.IntegerQuantity",
+        "fqn": "obf.datatype.IntegerQuantity",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-ConditionTopic.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-ConditionTopic.json
@@ -32,7 +32,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/us/core/ValueSet/us-core-problem",
               "bindingStrength": "EXTENSIBLE",
@@ -71,7 +71,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -83,16 +83,16 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/ConditionCategoryVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/ConditionCategoryVS",
               "bindingStrength": "REQUIRED",
               "lastModifiedBy": "cimi.topic.ConditionTopic"
             }
@@ -103,7 +103,7 @@
         "valueSet": [
           {
             "constraint": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/ConditionCategoryVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/ConditionCategoryVS",
               "bindingStrength": "REQUIRED",
               "lastModifiedBy": "cimi.topic.ConditionTopic"
             },

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-EvaluationMethod.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-EvaluationMethod.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The technique used to create the finding, for example, the specific imaging technical, lab test code, or assessment vehicle.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-EvaluationResultTopic.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-EvaluationResultTopic.json
@@ -47,7 +47,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -59,14 +59,14 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/observation-category",
               "bindingStrength": "EXTENSIBLE",

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-FindingMethod.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-FindingMethod.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The technique used to create the finding; for example, the specific imaging technique, lab test code, or assessment vehicle.\n\nCIMI Alignment: In CIMI V0.0.4, this attribute was called 'method'. The value set binding reflects CIMI's preference for LOINC codes.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-FindingTopic.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-FindingTopic.json
@@ -36,7 +36,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-Focus.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-Focus.json
@@ -14,7 +14,7 @@
     },
     "options": [
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       },
       {

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-PanelTopic.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-PanelTopic.json
@@ -42,7 +42,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -54,14 +54,14 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/observation-category",
               "bindingStrength": "EXTENSIBLE",

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-Precondition.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-Precondition.json
@@ -14,7 +14,7 @@
     },
     "options": [
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       },
       {

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-ReferenceRange.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-ReferenceRange.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.Range",
+    "fqn": "obf.datatype.Range",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -22,7 +22,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -30,7 +30,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/referencerange-meaning",
               "bindingStrength": "EXTENSIBLE",

--- a/test/fixtures/cimcore/cimi-topic/cimi-topic-TopicCode.json
+++ b/test/fixtures/cimcore/cimi-topic/cimi-topic-TopicCode.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The concept representing the finding or action that is the topic of the statement.\n\nFor action topics, the TopicCode represents the action being described. For findings, the TopicCode represents the 'question' or property being investigated. For evaluation result findings, the TopicCode contains a concept for an observable entity, such as systolic blood pressure. For assertion findings, the TopicCode contains a code representing the condition, allergy, or other item being asserted. In all cases, the TopicCode describes the topic independent of the context of the action or the finding.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-allergy/mappings/AdverseSensitivityToSubstance-mapping.json
+++ b/test/fixtures/cimcore/shr-allergy/mappings/AdverseSensitivityToSubstance-mapping.json
@@ -34,7 +34,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "assertedDate",
         "lastModifiedBy": "shr.allergy.AdverseSensitivityToSubstance"
@@ -50,7 +50,7 @@
       {
         "sourcePath": [
           "shr.allergy.AdverseSensitivityTopic",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "shr.allergy.AdverseSensitivityToSubstance"
@@ -125,7 +125,7 @@
         "sourcePath": [
           "shr.allergy.AdverseSensitivityPresenceContext",
           "shr.allergy.AdverseReaction",
-          "shr.core.Details"
+          "obf.datatype.Details"
         ],
         "target": "reaction.description",
         "lastModifiedBy": "shr.allergy.AdverseSensitivityToSubstance"
@@ -134,7 +134,7 @@
         "sourcePath": [
           "shr.allergy.AdverseSensitivityPresenceContext",
           "shr.allergy.AdverseReaction",
-          "shr.core.OccurrenceTime"
+          "obf.datatype.OccurrenceTime"
         ],
         "target": "reaction.onset",
         "lastModifiedBy": "shr.allergy.AdverseSensitivityToSubstance"

--- a/test/fixtures/cimcore/shr-allergy/mappings/NoAdverseSensitivityToSubstance-mapping.json
+++ b/test/fixtures/cimcore/shr-allergy/mappings/NoAdverseSensitivityToSubstance-mapping.json
@@ -34,7 +34,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "assertedDate",
         "lastModifiedBy": "shr.allergy.NoAdverseSensitivityToSubstance"

--- a/test/fixtures/cimcore/shr-allergy/mappings/NoKnownAllergy-mapping.json
+++ b/test/fixtures/cimcore/shr-allergy/mappings/NoKnownAllergy-mapping.json
@@ -38,7 +38,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "assertedDate",
         "lastModifiedBy": "shr.allergy.NoAdverseSensitivityToSubstance"

--- a/test/fixtures/cimcore/shr-allergy/mappings/NoKnownDrugAllergy-mapping.json
+++ b/test/fixtures/cimcore/shr-allergy/mappings/NoKnownDrugAllergy-mapping.json
@@ -38,7 +38,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "assertedDate",
         "lastModifiedBy": "shr.allergy.NoAdverseSensitivityToSubstance"

--- a/test/fixtures/cimcore/shr-allergy/mappings/NoKnownFoodAllergy-mapping.json
+++ b/test/fixtures/cimcore/shr-allergy/mappings/NoKnownFoodAllergy-mapping.json
@@ -38,7 +38,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "assertedDate",
         "lastModifiedBy": "shr.allergy.NoAdverseSensitivityToSubstance"

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-AdverseReaction.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-AdverseReaction.json
@@ -30,7 +30,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -38,7 +38,7 @@
       }
     },
     {
-      "fqn": "shr.core.OccurrenceTime",
+      "fqn": "obf.datatype.OccurrenceTime",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -54,7 +54,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/reaction-event-severity",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-AdverseSensitivityPresenceContext.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-AdverseSensitivityPresenceContext.json
@@ -27,7 +27,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/cimi/context/vs/PresenceContextVS",
               "bindingStrength": "REQUIRED",
@@ -73,7 +73,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/allergy-verification-status",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-AdverseSensitivityToSubstance.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-AdverseSensitivityToSubstance.json
@@ -213,7 +213,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-AdverseSensitivityTopic.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-AdverseSensitivityTopic.json
@@ -42,7 +42,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -92,7 +92,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -100,7 +100,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/allergy-intolerance-type",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-AllergenIrritant.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-AllergenIrritant.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A substance that causes an allergic reaction or irritation.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-Manifestation.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-Manifestation.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-NoAdverseSensitivityToSubstance.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-NoAdverseSensitivityToSubstance.json
@@ -206,7 +206,7 @@
         "subpaths": {
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/allergy/vs/NoKnownAllergyVS",
                   "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-NoKnownAllergy.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-NoKnownAllergy.json
@@ -203,7 +203,7 @@
         "subpaths": {
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-NoKnownDrugAllergy.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-NoKnownDrugAllergy.json
@@ -196,7 +196,7 @@
         "subpaths": {
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {

--- a/test/fixtures/cimcore/shr-allergy/shr-allergy-NoKnownFoodAllergy.json
+++ b/test/fixtures/cimcore/shr-allergy/shr-allergy-NoKnownFoodAllergy.json
@@ -196,7 +196,7 @@
         "subpaths": {
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {

--- a/test/fixtures/cimcore/shr-base/mappings/Entry-mapping.json
+++ b/test/fixtures/cimcore/shr-base/mappings/Entry-mapping.json
@@ -16,7 +16,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Version"
+          "obf.datatype.Version"
         ],
         "target": "meta.versionId",
         "lastModifiedBy": "shr.base.Entry"
@@ -37,7 +37,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Language"
+          "obf.datatype.Language"
         ],
         "target": "language",
         "lastModifiedBy": "shr.base.Entry"

--- a/test/fixtures/cimcore/shr-base/shr-base-Entry.json
+++ b/test/fixtures/cimcore/shr-base/shr-base-Entry.json
@@ -38,7 +38,7 @@
       }
     },
     {
-      "fqn": "shr.core.Version",
+      "fqn": "obf.datatype.Version",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -61,7 +61,7 @@
       }
     },
     {
-      "fqn": "shr.core.CreationTime",
+      "fqn": "obf.datatype.CreationTime",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -85,7 +85,7 @@
       }
     },
     {
-      "fqn": "shr.core.Language",
+      "fqn": "obf.datatype.Language",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-base/shr-base-SecurityLabel.json
+++ b/test/fixtures/cimcore/shr-base/shr-base-SecurityLabel.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A code that connects the entry to a security policy. Security labels can be updated when the resource changes, or whenever the security sub-system chooses to.",
   "value": {
-    "fqn": "shr.core.Coding",
+    "fqn": "obf.datatype.Coding",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-base/shr-base-Tag.json
+++ b/test/fixtures/cimcore/shr-base/shr-base-Tag.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A code used to relate entries to categories or workflows. Applications are not required to consider the tags when interpreting the meaning of an entry.",
   "value": {
-    "fqn": "shr.core.Coding",
+    "fqn": "obf.datatype.Coding",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-condition/mappings/BodyStructurePresenceStatement-mapping.json
+++ b/test/fixtures/cimcore/shr-condition/mappings/BodyStructurePresenceStatement-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "assertedDate",
         "lastModifiedBy": "cimi.statement.ConditionPresenceStatement"
@@ -37,7 +37,7 @@
       {
         "sourcePath": [
           "shr.condition.BodyStructureTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.ConditionPresenceStatement"
@@ -118,7 +118,7 @@
         "sourcePath": [
           "cimi.context.ConditionPresenceContext",
           "cimi.context.Stage",
-          "shr.core.CodeableConcept"
+          "obf.datatype.CodeableConcept"
         ],
         "target": "stage.summary",
         "lastModifiedBy": "cimi.statement.ConditionPresenceStatement"

--- a/test/fixtures/cimcore/shr-condition/mappings/DiseaseProgression-mapping.json
+++ b/test/fixtures/cimcore/shr-condition/mappings/DiseaseProgression-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-condition/shr-condition-BodyStructureTopic.json
+++ b/test/fixtures/cimcore/shr-condition/shr-condition-BodyStructureTopic.json
@@ -24,7 +24,7 @@
     "cimi.topic.ConditionTopic"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -60,7 +60,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {
@@ -114,7 +114,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -126,16 +126,16 @@
       }
     },
     {
-      "fqn": "shr.core.Category",
+      "fqn": "obf.datatype.Category",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/ConditionCategoryVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/ConditionCategoryVS",
               "bindingStrength": "REQUIRED",
               "lastModifiedBy": "cimi.topic.ConditionTopic"
             }
@@ -150,7 +150,7 @@
         "valueSet": [
           {
             "constraint": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/ConditionCategoryVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/ConditionCategoryVS",
               "bindingStrength": "REQUIRED"
             },
             "source": "cimi.topic.ConditionTopic"

--- a/test/fixtures/cimcore/shr-condition/shr-condition-DiseaseProgression.json
+++ b/test/fixtures/cimcore/shr-condition/shr-condition-DiseaseProgression.json
@@ -134,7 +134,7 @@
         "subpaths": {
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -149,7 +149,7 @@
           },
           "cimi.topic.Focus": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://hl7.org/fhir/us/core/ValueSet/us-core-problem",
                   "bindingStrength": "EXTENSIBLE",
@@ -278,12 +278,12 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.condition.DiseaseProgression"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/condition/vs/ProgressionVS",
                   "bindingStrength": "REQUIRED",
@@ -319,7 +319,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.condition.DiseaseProgression"
             },

--- a/test/fixtures/cimcore/shr-condition/shr-condition-Morphology.json
+++ b/test/fixtures/cimcore/shr-condition/shr-condition-Morphology.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The kind of structure being represented. This can define both normal and abnormal morphologies.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-condition/shr-condition-ProgressionEvidence.json
+++ b/test/fixtures/cimcore/shr-condition/shr-condition-ProgressionEvidence.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The type of evidence considered in determining disease progression.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/mappings/Address-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Address-mapping.json
@@ -1,81 +1,81 @@
 {
   "fileType": "Mapping",
   "name": "Address",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Address",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Address",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Address",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Purpose"
+          "obf.datatype.Purpose"
         ],
         "target": "use",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.DisplayText"
+          "obf.datatype.DisplayText"
         ],
         "target": "text",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.AddressLine"
+          "obf.datatype.AddressLine"
         ],
         "target": "line",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.City"
+          "obf.datatype.City"
         ],
         "target": "city",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.District"
+          "obf.datatype.District"
         ],
         "target": "district",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.State"
+          "obf.datatype.State"
         ],
         "target": "state",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.PostalCode"
+          "obf.datatype.PostalCode"
         ],
         "target": "postalCode",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.Country"
+          "obf.datatype.Country"
         ],
         "target": "country",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Age-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Age-mapping.json
@@ -1,13 +1,13 @@
 {
   "fileType": "Mapping",
   "name": "Age",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Age",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Age",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Age",
   "inheritance": {
     "status": "overridden",
-    "from": "shr.core.Quantity"
+    "from": "obf.datatype.Quantity"
   },
   "mappings": {
     "fieldMapping": [
@@ -16,41 +16,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Attachment-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Attachment-mapping.json
@@ -1,67 +1,67 @@
 {
   "fileType": "Mapping",
   "name": "Attachment",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Attachment",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Attachment",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Attachment",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.BinaryData"
+          "obf.datatype.BinaryData"
         ],
         "target": "data",
-        "lastModifiedBy": "shr.core.Attachment"
+        "lastModifiedBy": "obf.datatype.Attachment"
       },
       {
         "sourcePath": [
-          "shr.core.ContentType"
+          "obf.datatype.ContentType"
         ],
         "target": "contentType",
-        "lastModifiedBy": "shr.core.Attachment"
+        "lastModifiedBy": "obf.datatype.Attachment"
       },
       {
         "sourcePath": [
-          "shr.core.Language"
+          "obf.datatype.Language"
         ],
         "target": "language",
-        "lastModifiedBy": "shr.core.Attachment"
+        "lastModifiedBy": "obf.datatype.Attachment"
       },
       {
         "sourcePath": [
-          "shr.core.ResourceLocation"
+          "obf.datatype.ResourceLocation"
         ],
         "target": "url",
-        "lastModifiedBy": "shr.core.Attachment"
+        "lastModifiedBy": "obf.datatype.Attachment"
       },
       {
         "sourcePath": [
-          "shr.core.ResourceSize"
+          "obf.datatype.ResourceSize"
         ],
         "target": "size",
-        "lastModifiedBy": "shr.core.Attachment"
+        "lastModifiedBy": "obf.datatype.Attachment"
       },
       {
         "sourcePath": [
-          "shr.core.Hash"
+          "obf.datatype.Hash"
         ],
         "target": "hash",
-        "lastModifiedBy": "shr.core.Attachment"
+        "lastModifiedBy": "obf.datatype.Attachment"
       },
       {
         "sourcePath": [
-          "shr.core.Title"
+          "obf.datatype.Title"
         ],
         "target": "title",
-        "lastModifiedBy": "shr.core.Attachment"
+        "lastModifiedBy": "obf.datatype.Attachment"
       },
       {
         "sourcePath": [
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "creation",
-        "lastModifiedBy": "shr.core.Attachment"
+        "lastModifiedBy": "obf.datatype.Attachment"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/CodeableConcept-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/CodeableConcept-mapping.json
@@ -1,25 +1,25 @@
 {
   "fileType": "Mapping",
   "name": "CodeableConcept",
-  "namespace": "shr.core",
-  "fqn": "shr.core.CodeableConcept",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.CodeableConcept",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "CodeableConcept",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Coding"
+          "obf.datatype.Coding"
         ],
         "target": "coding",
-        "lastModifiedBy": "shr.core.CodeableConcept"
+        "lastModifiedBy": "obf.datatype.CodeableConcept"
       },
       {
         "sourcePath": [
-          "shr.core.DisplayText"
+          "obf.datatype.DisplayText"
         ],
         "target": "text",
-        "lastModifiedBy": "shr.core.CodeableConcept"
+        "lastModifiedBy": "obf.datatype.CodeableConcept"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Coding-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Coding-mapping.json
@@ -1,8 +1,8 @@
 {
   "fileType": "Mapping",
   "name": "Coding",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Coding",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Coding",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Coding",
   "mappings": {
@@ -12,28 +12,28 @@
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Coding"
+        "lastModifiedBy": "obf.datatype.Coding"
       },
       {
         "sourcePath": [
-          "shr.core.CodeSystem"
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Coding"
+        "lastModifiedBy": "obf.datatype.Coding"
       },
       {
         "sourcePath": [
-          "shr.core.CodeSystemVersion"
+          "obf.datatype.CodeSystemVersion"
         ],
         "target": "version",
-        "lastModifiedBy": "shr.core.Coding"
+        "lastModifiedBy": "obf.datatype.Coding"
       },
       {
         "sourcePath": [
-          "shr.core.DisplayText"
+          "obf.datatype.DisplayText"
         ],
         "target": "display",
-        "lastModifiedBy": "shr.core.Coding"
+        "lastModifiedBy": "obf.datatype.Coding"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/ContactDetail-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/ContactDetail-mapping.json
@@ -1,26 +1,26 @@
 {
   "fileType": "Mapping",
   "name": "ContactDetail",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ContactDetail",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ContactDetail",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "ContactDetail",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.HumanName",
+          "obf.datatype.HumanName",
           "cimi.element.NameAsText"
         ],
         "target": "name",
-        "lastModifiedBy": "shr.core.ContactDetail"
+        "lastModifiedBy": "obf.datatype.ContactDetail"
       },
       {
         "sourcePath": [
-          "shr.core.ContactPoint"
+          "obf.datatype.ContactPoint"
         ],
         "target": "telecom",
-        "lastModifiedBy": "shr.core.ContactDetail"
+        "lastModifiedBy": "obf.datatype.ContactDetail"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/ContactPoint-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/ContactPoint-mapping.json
@@ -1,46 +1,46 @@
 {
   "fileType": "Mapping",
   "name": "ContactPoint",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ContactPoint",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ContactPoint",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "ContactPoint",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.TelecomNumberOrAddress"
+          "obf.datatype.TelecomNumberOrAddress"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.ContactPoint"
+        "lastModifiedBy": "obf.datatype.ContactPoint"
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.ContactPoint"
+        "lastModifiedBy": "obf.datatype.ContactPoint"
       },
       {
         "sourcePath": [
-          "shr.core.Purpose"
+          "obf.datatype.Purpose"
         ],
         "target": "use",
-        "lastModifiedBy": "shr.core.ContactPoint"
+        "lastModifiedBy": "obf.datatype.ContactPoint"
       },
       {
         "sourcePath": [
-          "shr.core.PriorityRank"
+          "obf.datatype.PriorityRank"
         ],
         "target": "rank",
-        "lastModifiedBy": "shr.core.ContactPoint"
+        "lastModifiedBy": "obf.datatype.ContactPoint"
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
-        "lastModifiedBy": "shr.core.ContactPoint"
+        "lastModifiedBy": "obf.datatype.ContactPoint"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Distance-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Distance-mapping.json
@@ -1,13 +1,13 @@
 {
   "fileType": "Mapping",
   "name": "Distance",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Distance",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Distance",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Distance",
   "inheritance": {
     "status": "overridden",
-    "from": "shr.core.Quantity"
+    "from": "obf.datatype.Quantity"
   },
   "mappings": {
     "fieldMapping": [
@@ -16,41 +16,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Duration-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Duration-mapping.json
@@ -1,13 +1,13 @@
 {
   "fileType": "Mapping",
   "name": "Duration",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Duration",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Duration",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Duration",
   "inheritance": {
     "status": "overridden",
-    "from": "shr.core.Quantity"
+    "from": "obf.datatype.Quantity"
   },
   "mappings": {
     "fieldMapping": [
@@ -16,41 +16,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/EffectiveTimePeriod-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/EffectiveTimePeriod-mapping.json
@@ -1,29 +1,29 @@
 {
   "fileType": "Mapping",
   "name": "EffectiveTimePeriod",
-  "namespace": "shr.core",
-  "fqn": "shr.core.EffectiveTimePeriod",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.EffectiveTimePeriod",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Period",
   "inheritance": {
     "status": "inherited",
-    "from": "shr.core.TimePeriod"
+    "from": "obf.datatype.TimePeriod"
   },
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.TimePeriodStart"
+          "obf.datatype.TimePeriodStart"
         ],
         "target": "start",
-        "lastModifiedBy": "shr.core.TimePeriod"
+        "lastModifiedBy": "obf.datatype.TimePeriod"
       },
       {
         "sourcePath": [
-          "shr.core.TimePeriodEnd"
+          "obf.datatype.TimePeriodEnd"
         ],
         "target": "end",
-        "lastModifiedBy": "shr.core.TimePeriod"
+        "lastModifiedBy": "obf.datatype.TimePeriod"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Frequency-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Frequency-mapping.json
@@ -1,29 +1,29 @@
 {
   "fileType": "Mapping",
   "name": "Frequency",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Frequency",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Frequency",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Ratio",
   "inheritance": {
     "status": "inherited",
-    "from": "shr.core.Ratio"
+    "from": "obf.datatype.Ratio"
   },
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Numerator"
+          "obf.datatype.Numerator"
         ],
         "target": "numerator",
-        "lastModifiedBy": "shr.core.Ratio"
+        "lastModifiedBy": "obf.datatype.Ratio"
       },
       {
         "sourcePath": [
-          "shr.core.Denominator"
+          "obf.datatype.Denominator"
         ],
         "target": "denominator",
-        "lastModifiedBy": "shr.core.Ratio"
+        "lastModifiedBy": "obf.datatype.Ratio"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Geoposition-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Geoposition-mapping.json
@@ -1,32 +1,32 @@
 {
   "fileType": "Mapping",
   "name": "Geoposition",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Geoposition",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Geoposition",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Latitude"
+          "obf.datatype.Latitude"
         ],
         "target": "position.latitude",
-        "lastModifiedBy": "shr.core.Geoposition"
+        "lastModifiedBy": "obf.datatype.Geoposition"
       },
       {
         "sourcePath": [
-          "shr.core.Longitude"
+          "obf.datatype.Longitude"
         ],
         "target": "position.longitude",
-        "lastModifiedBy": "shr.core.Geoposition"
+        "lastModifiedBy": "obf.datatype.Geoposition"
       },
       {
         "sourcePath": [
-          "shr.core.Altitude"
+          "obf.datatype.Altitude"
         ],
         "target": "position.altitude",
-        "lastModifiedBy": "shr.core.Geoposition"
+        "lastModifiedBy": "obf.datatype.Geoposition"
       }
     ],
     "cardMapping": [
@@ -36,7 +36,7 @@
           "max": 1
         },
         "target": "position",
-        "lastModifiedBy": "shr.core.Geoposition"
+        "lastModifiedBy": "obf.datatype.Geoposition"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/GestationalAge-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/GestationalAge-mapping.json
@@ -1,13 +1,13 @@
 {
   "fileType": "Mapping",
   "name": "GestationalAge",
-  "namespace": "shr.core",
-  "fqn": "shr.core.GestationalAge",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.GestationalAge",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Age",
   "inheritance": {
     "status": "inherited",
-    "from": "shr.core.Age"
+    "from": "obf.datatype.Age"
   },
   "mappings": {
     "fieldMapping": [
@@ -16,41 +16,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/HumanName-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/HumanName-mapping.json
@@ -1,8 +1,8 @@
 {
   "fileType": "Mapping",
   "name": "HumanName",
-  "namespace": "shr.core",
-  "fqn": "shr.core.HumanName",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.HumanName",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "HumanName",
   "mappings": {
@@ -12,49 +12,49 @@
           "cimi.element.NameAsText"
         ],
         "target": "text",
-        "lastModifiedBy": "shr.core.HumanName"
+        "lastModifiedBy": "obf.datatype.HumanName"
       },
       {
         "sourcePath": [
           "cimi.element.Prefix"
         ],
         "target": "prefix",
-        "lastModifiedBy": "shr.core.HumanName"
+        "lastModifiedBy": "obf.datatype.HumanName"
       },
       {
         "sourcePath": [
           "cimi.element.GivenName"
         ],
         "target": "given",
-        "lastModifiedBy": "shr.core.HumanName"
+        "lastModifiedBy": "obf.datatype.HumanName"
       },
       {
         "sourcePath": [
           "cimi.element.FamilyName"
         ],
         "target": "family",
-        "lastModifiedBy": "shr.core.HumanName"
+        "lastModifiedBy": "obf.datatype.HumanName"
       },
       {
         "sourcePath": [
           "cimi.element.Suffix"
         ],
         "target": "suffix",
-        "lastModifiedBy": "shr.core.HumanName"
+        "lastModifiedBy": "obf.datatype.HumanName"
       },
       {
         "sourcePath": [
-          "shr.core.Purpose"
+          "obf.datatype.Purpose"
         ],
         "target": "use",
-        "lastModifiedBy": "shr.core.HumanName"
+        "lastModifiedBy": "obf.datatype.HumanName"
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
-        "lastModifiedBy": "shr.core.HumanName"
+        "lastModifiedBy": "obf.datatype.HumanName"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/IntegerQuantity-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/IntegerQuantity-mapping.json
@@ -1,13 +1,13 @@
 {
   "fileType": "Mapping",
   "name": "IntegerQuantity",
-  "namespace": "shr.core",
-  "fqn": "shr.core.IntegerQuantity",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.IntegerQuantity",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Count",
   "inheritance": {
     "status": "overridden",
-    "from": "shr.core.Quantity"
+    "from": "obf.datatype.Quantity"
   },
   "mappings": {
     "fieldMapping": [
@@ -16,41 +16,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Money-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Money-mapping.json
@@ -1,13 +1,13 @@
 {
   "fileType": "Mapping",
   "name": "Money",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Money",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Money",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Money",
   "inheritance": {
     "status": "overridden",
-    "from": "shr.core.Quantity"
+    "from": "obf.datatype.Quantity"
   },
   "mappings": {
     "fieldMapping": [
@@ -16,41 +16,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Percentage-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Percentage-mapping.json
@@ -1,13 +1,13 @@
 {
   "fileType": "Mapping",
   "name": "Percentage",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Percentage",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Percentage",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "SimpleQuantity",
   "inheritance": {
     "status": "inherited",
-    "from": "shr.core.SimpleQuantity"
+    "from": "obf.datatype.SimpleQuantity"
   },
   "mappings": {
     "fieldMapping": [
@@ -16,41 +16,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/PercentageRange-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/PercentageRange-mapping.json
@@ -1,29 +1,29 @@
 {
   "fileType": "Mapping",
   "name": "PercentageRange",
-  "namespace": "shr.core",
-  "fqn": "shr.core.PercentageRange",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.PercentageRange",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Range",
   "inheritance": {
     "status": "inherited",
-    "from": "shr.core.Range"
+    "from": "obf.datatype.Range"
   },
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.LowerBound"
+          "obf.datatype.LowerBound"
         ],
         "target": "low",
-        "lastModifiedBy": "shr.core.Range"
+        "lastModifiedBy": "obf.datatype.Range"
       },
       {
         "sourcePath": [
-          "shr.core.UpperBound"
+          "obf.datatype.UpperBound"
         ],
         "target": "high",
-        "lastModifiedBy": "shr.core.Range"
+        "lastModifiedBy": "obf.datatype.Range"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Quantity-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Quantity-mapping.json
@@ -1,8 +1,8 @@
 {
   "fileType": "Mapping",
   "name": "Quantity",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Quantity",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Quantity",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Quantity",
   "mappings": {
@@ -12,41 +12,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Range-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Range-mapping.json
@@ -1,25 +1,25 @@
 {
   "fileType": "Mapping",
   "name": "Range",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Range",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Range",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Range",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.LowerBound"
+          "obf.datatype.LowerBound"
         ],
         "target": "low",
-        "lastModifiedBy": "shr.core.Range"
+        "lastModifiedBy": "obf.datatype.Range"
       },
       {
         "sourcePath": [
-          "shr.core.UpperBound"
+          "obf.datatype.UpperBound"
         ],
         "target": "high",
-        "lastModifiedBy": "shr.core.Range"
+        "lastModifiedBy": "obf.datatype.Range"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Ratio-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Ratio-mapping.json
@@ -1,25 +1,25 @@
 {
   "fileType": "Mapping",
   "name": "Ratio",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Ratio",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Ratio",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Ratio",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Numerator"
+          "obf.datatype.Numerator"
         ],
         "target": "numerator",
-        "lastModifiedBy": "shr.core.Ratio"
+        "lastModifiedBy": "obf.datatype.Ratio"
       },
       {
         "sourcePath": [
-          "shr.core.Denominator"
+          "obf.datatype.Denominator"
         ],
         "target": "denominator",
-        "lastModifiedBy": "shr.core.Ratio"
+        "lastModifiedBy": "obf.datatype.Ratio"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/SampledData-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/SampledData-mapping.json
@@ -1,8 +1,8 @@
 {
   "fileType": "Mapping",
   "name": "SampledData",
-  "namespace": "shr.core",
-  "fqn": "shr.core.SampledData",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.SampledData",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "SampledData",
   "mappings": {
@@ -12,49 +12,49 @@
           "string"
         ],
         "target": "data",
-        "lastModifiedBy": "shr.core.SampledData"
+        "lastModifiedBy": "obf.datatype.SampledData"
       },
       {
         "sourcePath": [
-          "shr.core.Origin"
+          "obf.datatype.Origin"
         ],
         "target": "origin",
-        "lastModifiedBy": "shr.core.SampledData"
+        "lastModifiedBy": "obf.datatype.SampledData"
       },
       {
         "sourcePath": [
-          "shr.core.MillisecondsBetweenSamples"
+          "obf.datatype.MillisecondsBetweenSamples"
         ],
         "target": "period",
-        "lastModifiedBy": "shr.core.SampledData"
+        "lastModifiedBy": "obf.datatype.SampledData"
       },
       {
         "sourcePath": [
-          "shr.core.CorrectionFactor"
+          "obf.datatype.CorrectionFactor"
         ],
         "target": "factor",
-        "lastModifiedBy": "shr.core.SampledData"
+        "lastModifiedBy": "obf.datatype.SampledData"
       },
       {
         "sourcePath": [
-          "shr.core.LowerLimit"
+          "obf.datatype.LowerLimit"
         ],
         "target": "lowerLimit",
-        "lastModifiedBy": "shr.core.SampledData"
+        "lastModifiedBy": "obf.datatype.SampledData"
       },
       {
         "sourcePath": [
-          "shr.core.UpperLimit"
+          "obf.datatype.UpperLimit"
         ],
         "target": "upperLimit",
-        "lastModifiedBy": "shr.core.SampledData"
+        "lastModifiedBy": "obf.datatype.SampledData"
       },
       {
         "sourcePath": [
-          "shr.core.Dimensions"
+          "obf.datatype.Dimensions"
         ],
         "target": "dimensions",
-        "lastModifiedBy": "shr.core.SampledData"
+        "lastModifiedBy": "obf.datatype.SampledData"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/SimpleQuantity-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/SimpleQuantity-mapping.json
@@ -1,13 +1,13 @@
 {
   "fileType": "Mapping",
   "name": "SimpleQuantity",
-  "namespace": "shr.core",
-  "fqn": "shr.core.SimpleQuantity",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.SimpleQuantity",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "SimpleQuantity",
   "inheritance": {
     "status": "overridden",
-    "from": "shr.core.Quantity"
+    "from": "obf.datatype.Quantity"
   },
   "mappings": {
     "fieldMapping": [
@@ -16,41 +16,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Statistic-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Statistic-mapping.json
@@ -1,13 +1,13 @@
 {
   "fileType": "Mapping",
   "name": "Statistic",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Statistic",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Statistic",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Quantity",
   "inheritance": {
     "status": "inherited",
-    "from": "shr.core.Quantity"
+    "from": "obf.datatype.Quantity"
   },
   "mappings": {
     "fieldMapping": [
@@ -16,41 +16,41 @@
           "decimal"
         ],
         "target": "value",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.CodeSystem"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.CodeSystem"
         ],
         "target": "system",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Units",
-          "shr.core.Coding",
-          "shr.core.DisplayText"
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
+          "obf.datatype.DisplayText"
         ],
         "target": "unit",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       },
       {
         "sourcePath": [
-          "shr.core.Comparator"
+          "obf.datatype.Comparator"
         ],
         "target": "comparator",
-        "lastModifiedBy": "shr.core.Quantity"
+        "lastModifiedBy": "obf.datatype.Quantity"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/TimePeriod-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/TimePeriod-mapping.json
@@ -1,25 +1,25 @@
 {
   "fileType": "Mapping",
   "name": "TimePeriod",
-  "namespace": "shr.core",
-  "fqn": "shr.core.TimePeriod",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.TimePeriod",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Period",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.TimePeriodStart"
+          "obf.datatype.TimePeriodStart"
         ],
         "target": "start",
-        "lastModifiedBy": "shr.core.TimePeriod"
+        "lastModifiedBy": "obf.datatype.TimePeriod"
       },
       {
         "sourcePath": [
-          "shr.core.TimePeriodEnd"
+          "obf.datatype.TimePeriodEnd"
         ],
         "target": "end",
-        "lastModifiedBy": "shr.core.TimePeriod"
+        "lastModifiedBy": "obf.datatype.TimePeriod"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/Timing-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/Timing-mapping.json
@@ -1,127 +1,127 @@
 {
   "fileType": "Mapping",
   "name": "Timing",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Timing",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Timing",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Timing",
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.OccurrenceTime"
+          "obf.datatype.OccurrenceTime"
         ],
         "target": "event",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.TimingCode"
+          "obf.datatype.TimingCode"
         ],
         "target": "code",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.EventDuration",
-          "shr.core.DurationRange",
-          "shr.core.LowerBound"
+          "obf.datatype.EventDuration",
+          "obf.datatype.DurationRange",
+          "obf.datatype.LowerBound"
         ],
         "target": "repeat.duration",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.EventDuration",
-          "shr.core.DurationRange",
-          "shr.core.UpperBound"
+          "obf.datatype.EventDuration",
+          "obf.datatype.DurationRange",
+          "obf.datatype.UpperBound"
         ],
         "target": "repeat.durationMax",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.EventDuration",
-          "shr.core.DurationRange",
-          "shr.core.LowerBound",
-          "shr.core.Quantity",
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.EventDuration",
+          "obf.datatype.DurationRange",
+          "obf.datatype.LowerBound",
+          "obf.datatype.Quantity",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "repeat.durationUnit",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.RecurrencePattern",
-          "shr.core.RecurrenceInterval",
-          "shr.core.Duration"
+          "obf.datatype.RecurrencePattern",
+          "obf.datatype.RecurrenceInterval",
+          "obf.datatype.Duration"
         ],
         "target": "repeat.period",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.RecurrencePattern",
-          "shr.core.RecurrenceInterval",
-          "shr.core.Duration",
-          "shr.core.Units",
-          "shr.core.Coding",
+          "obf.datatype.RecurrencePattern",
+          "obf.datatype.RecurrenceInterval",
+          "obf.datatype.Duration",
+          "obf.datatype.Units",
+          "obf.datatype.Coding",
           "code"
         ],
         "target": "repeat.periodUnit",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.RecurrencePattern",
-          "shr.core.DayOfWeek"
+          "obf.datatype.RecurrencePattern",
+          "obf.datatype.DayOfWeek"
         ],
         "target": "repeat.dayOfWeek",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.RecurrencePattern",
-          "shr.core.TimeOfDay"
+          "obf.datatype.RecurrencePattern",
+          "obf.datatype.TimeOfDay"
         ],
         "target": "repeat.timeOfDay",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.RecurrencePattern",
-          "shr.core.DailyLifeEvent"
+          "obf.datatype.RecurrencePattern",
+          "obf.datatype.DailyLifeEvent"
         ],
         "target": "repeat.when",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.RecurrencePattern",
-          "shr.core.LifeEventOffset"
+          "obf.datatype.RecurrencePattern",
+          "obf.datatype.LifeEventOffset"
         ],
         "target": "repeat.offset",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.RecurrencePattern",
-          "shr.core.CountPerInterval",
-          "shr.core.MinCount"
+          "obf.datatype.RecurrencePattern",
+          "obf.datatype.CountPerInterval",
+          "obf.datatype.MinCount"
         ],
         "target": "repeat.frequency",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       },
       {
         "sourcePath": [
-          "shr.core.RecurrencePattern",
-          "shr.core.CountPerInterval",
-          "shr.core.MaxCount"
+          "obf.datatype.RecurrencePattern",
+          "obf.datatype.CountPerInterval",
+          "obf.datatype.MaxCount"
         ],
         "target": "repeat.frequencyMax",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       }
     ],
     "cardMapping": [
@@ -131,7 +131,7 @@
           "max": 0
         },
         "target": "repeat.periodMax",
-        "lastModifiedBy": "shr.core.Timing"
+        "lastModifiedBy": "obf.datatype.Timing"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/mappings/UnitedStatesAddress-mapping.json
+++ b/test/fixtures/cimcore/shr-core/mappings/UnitedStatesAddress-mapping.json
@@ -1,85 +1,85 @@
 {
   "fileType": "Mapping",
   "name": "UnitedStatesAddress",
-  "namespace": "shr.core",
-  "fqn": "shr.core.UnitedStatesAddress",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.UnitedStatesAddress",
   "targetSpec": "FHIR_STU_3",
   "targetItem": "Address",
   "inheritance": {
     "status": "inherited",
-    "from": "shr.core.Address"
+    "from": "obf.datatype.Address"
   },
   "mappings": {
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Purpose"
+          "obf.datatype.Purpose"
         ],
         "target": "use",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.DisplayText"
+          "obf.datatype.DisplayText"
         ],
         "target": "text",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.AddressLine"
+          "obf.datatype.AddressLine"
         ],
         "target": "line",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.City"
+          "obf.datatype.City"
         ],
         "target": "city",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.District"
+          "obf.datatype.District"
         ],
         "target": "district",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.UnitedStatesState"
+          "obf.datatype.UnitedStatesState"
         ],
         "target": "state",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.PostalCode"
+          "obf.datatype.PostalCode"
         ],
         "target": "postalCode",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.Country"
+          "obf.datatype.Country"
         ],
         "target": "country",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
-        "lastModifiedBy": "shr.core.Address"
+        "lastModifiedBy": "obf.datatype.Address"
       }
     ]
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-Address.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Address.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Address",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Address",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Address",
   "isEntry": false,
   "isAbstract": false,
   "description": "An address expressed using postal conventions (as opposed to GPS or other location definition formats). This data type may be used to convey addresses for use in delivering mail as well as for visiting locations and which might not be valid for mail delivery. There are a variety of postal address formats defined around the world. (Source: HL7 FHIR).",
@@ -14,7 +14,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -22,18 +22,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/address-use",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Address"
+              "lastModifiedBy": "obf.datatype.Address"
             }
           }
         }
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -41,18 +41,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/address-type",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Address"
+              "lastModifiedBy": "obf.datatype.Address"
             }
           }
         }
       }
     },
     {
-      "fqn": "shr.core.DisplayText",
+      "fqn": "obf.datatype.DisplayText",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -60,7 +60,7 @@
       }
     },
     {
-      "fqn": "shr.core.AddressLine",
+      "fqn": "obf.datatype.AddressLine",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "fqn": "shr.core.City",
+      "fqn": "obf.datatype.City",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -76,7 +76,7 @@
       }
     },
     {
-      "fqn": "shr.core.District",
+      "fqn": "obf.datatype.District",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -84,7 +84,7 @@
       }
     },
     {
-      "fqn": "shr.core.State",
+      "fqn": "obf.datatype.State",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -92,7 +92,7 @@
       }
     },
     {
-      "fqn": "shr.core.PostalCode",
+      "fqn": "obf.datatype.PostalCode",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "fqn": "shr.core.Country",
+      "fqn": "obf.datatype.Country",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-AddressLine.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-AddressLine.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "AddressLine",
-  "namespace": "shr.core",
-  "fqn": "shr.core.AddressLine",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.AddressLine",
   "isEntry": false,
   "isAbstract": false,
   "description": "Part of an address that contains the house number, apartment number, street name, street direction, P.O. Box number, delivery hints, and similar address information. (Source: HL7 FHIR).",

--- a/test/fixtures/cimcore/shr-core/shr-core-Age.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Age.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Age",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Age",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Age",
   "isEntry": false,
   "isAbstract": false,
   "description": "How long something has existed in time.",
@@ -13,10 +13,10 @@
     }
   ],
   "hierarchy": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "basedOn": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "value": {
     "fqn": "decimal",
@@ -27,12 +27,12 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.Quantity"
+      "from": "obf.datatype.Quantity"
     }
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -40,11 +40,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -52,18 +52,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/units-of-time",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Age"
+              "lastModifiedBy": "obf.datatype.Age"
             }
           }
         }
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       },
       "constraintHistory": {
         "valueSet": [
@@ -71,9 +71,9 @@
             "constraint": {
               "uri": "http://hl7.org/fhir/ValueSet/units-of-time",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Age"
+              "lastModifiedBy": "obf.datatype.Age"
             },
-            "source": "shr.core.Age"
+            "source": "obf.datatype.Age"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-AgeGroup.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-AgeGroup.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "AgeGroup",
-  "namespace": "shr.core",
-  "fqn": "shr.core.AgeGroup",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.AgeGroup",
   "isEntry": false,
   "isAbstract": false,
   "description": "Subgroups of populations based on age.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,9 +21,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/AgeGroupVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/AgeGroupVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.AgeGroup"
+        "lastModifiedBy": "obf.datatype.AgeGroup"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-AgeRange.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-AgeRange.json
@@ -1,14 +1,14 @@
 {
   "fileType": "DataElement",
   "name": "AgeRange",
-  "namespace": "shr.core",
-  "fqn": "shr.core.AgeRange",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.AgeRange",
   "isEntry": false,
   "isAbstract": false,
   "description": "A quantitative range of ages. One of the two ages must be specified.",
   "fields": [
     {
-      "fqn": "shr.core.UpperBound",
+      "fqn": "obf.datatype.UpperBound",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -16,18 +16,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "type": {
-              "fqn": "shr.core.Age",
+              "fqn": "obf.datatype.Age",
               "onValue": false,
-              "lastModifiedBy": "shr.core.AgeRange"
+              "lastModifiedBy": "obf.datatype.AgeRange"
             }
           }
         }
       }
     },
     {
-      "fqn": "shr.core.LowerBound",
+      "fqn": "obf.datatype.LowerBound",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -35,11 +35,11 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "type": {
-              "fqn": "shr.core.Age",
+              "fqn": "obf.datatype.Age",
               "onValue": false,
-              "lastModifiedBy": "shr.core.AgeRange"
+              "lastModifiedBy": "obf.datatype.AgeRange"
             }
           }
         }

--- a/test/fixtures/cimcore/shr-core/shr-core-Altitude.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Altitude.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Altitude",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Altitude",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Altitude",
   "isEntry": false,
   "isAbstract": false,
   "description": "Height above sea level or above the earth's surface. Measured with with WGS84 datum.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Area.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Area.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Area",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Area",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Area",
   "isEntry": false,
   "isAbstract": false,
   "description": "The extent of a 2-dimensional surface enclosed within a boundary.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,16 +21,16 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {
                   "system": "http://unitsofmeasure.org",
                   "code": "TBD"
                 },
-                "lastModifiedBy": "shr.core.Area"
+                "lastModifiedBy": "obf.datatype.Area"
               }
             }
           }

--- a/test/fixtures/cimcore/shr-core/shr-core-Attachment.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Attachment.json
@@ -1,20 +1,20 @@
 {
   "fileType": "DataElement",
   "name": "Attachment",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Attachment",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Attachment",
   "isEntry": false,
   "isAbstract": false,
   "description": "A file that contains audio, video, image, or similar content.",
   "hierarchy": [
-    "shr.core.EmbeddedContent"
+    "obf.datatype.EmbeddedContent"
   ],
   "basedOn": [
-    "shr.core.EmbeddedContent"
+    "obf.datatype.EmbeddedContent"
   ],
   "fields": [
     {
-      "fqn": "shr.core.BinaryData",
+      "fqn": "obf.datatype.BinaryData",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "fqn": "shr.core.ContentType",
+      "fqn": "obf.datatype.ContentType",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -30,7 +30,7 @@
       }
     },
     {
-      "fqn": "shr.core.Language",
+      "fqn": "obf.datatype.Language",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -38,7 +38,7 @@
       }
     },
     {
-      "fqn": "shr.core.ResourceLocation",
+      "fqn": "obf.datatype.ResourceLocation",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -46,7 +46,7 @@
       }
     },
     {
-      "fqn": "shr.core.ResourceSize",
+      "fqn": "obf.datatype.ResourceSize",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -54,7 +54,7 @@
       }
     },
     {
-      "fqn": "shr.core.Hash",
+      "fqn": "obf.datatype.Hash",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -62,7 +62,7 @@
       }
     },
     {
-      "fqn": "shr.core.Title",
+      "fqn": "obf.datatype.Title",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -70,7 +70,7 @@
       }
     },
     {
-      "fqn": "shr.core.CreationTime",
+      "fqn": "obf.datatype.CreationTime",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-BinaryData.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-BinaryData.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "BinaryData",
-  "namespace": "shr.core",
-  "fqn": "shr.core.BinaryData",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.BinaryData",
   "isEntry": false,
   "isAbstract": false,
   "description": "The data itself.",

--- a/test/fixtures/cimcore/shr-core/shr-core-BodyPosition.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-BodyPosition.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "BodyPosition",
-  "namespace": "shr.core",
-  "fqn": "shr.core.BodyPosition",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.BodyPosition",
   "isEntry": false,
   "isAbstract": false,
   "description": "The position or physical attitude of the body.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,9 +21,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/BodyPositionVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/BodyPositionVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.BodyPosition"
+        "lastModifiedBy": "obf.datatype.BodyPosition"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-Category.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Category.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "Category",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Category",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Category",
   "isEntry": false,
   "isAbstract": false,
   "description": "A class or division of people or things having particular shared characteristics",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-Circumference.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Circumference.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Circumference",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Circumference",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Circumference",
   "isEntry": false,
   "isAbstract": false,
   "description": "The length of such a boundary line of a figure, area, or object.",

--- a/test/fixtures/cimcore/shr-core/shr-core-City.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-City.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "City",
-  "namespace": "shr.core",
-  "fqn": "shr.core.City",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.City",
   "isEntry": false,
   "isAbstract": false,
   "description": "The name of a municipality, city, town, village or other community or delivery center. (Source: HL7 FHIR).",
@@ -13,10 +13,10 @@
     }
   ],
   "hierarchy": [
-    "shr.core.GeopoliticalLocation"
+    "obf.datatype.GeopoliticalLocation"
   ],
   "basedOn": [
-    "shr.core.GeopoliticalLocation"
+    "obf.datatype.GeopoliticalLocation"
   ],
   "value": {
     "fqn": "string",

--- a/test/fixtures/cimcore/shr-core/shr-core-ClockDirection.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-ClockDirection.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "ClockDirection",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ClockDirection",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ClockDirection",
   "isEntry": false,
   "isAbstract": false,
   "description": "A direction indicated by an angle relative to 12 o'clock.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,9 +21,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/ClockDirectionVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/ClockDirectionVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.ClockDirection"
+        "lastModifiedBy": "obf.datatype.ClockDirection"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-CodeSystem.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-CodeSystem.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "CodeSystem",
-  "namespace": "shr.core",
-  "fqn": "shr.core.CodeSystem",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.CodeSystem",
   "isEntry": false,
   "isAbstract": false,
   "description": "A formal terminology system.",

--- a/test/fixtures/cimcore/shr-core/shr-core-CodeSystemVersion.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-CodeSystemVersion.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "CodeSystemVersion",
-  "namespace": "shr.core",
-  "fqn": "shr.core.CodeSystemVersion",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.CodeSystemVersion",
   "isEntry": false,
   "isAbstract": false,
   "description": "The version of the vocabulary being used, if applicable.",

--- a/test/fixtures/cimcore/shr-core/shr-core-CodeableConcept.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-CodeableConcept.json
@@ -1,21 +1,21 @@
 {
   "fileType": "DataElement",
   "name": "CodeableConcept",
-  "namespace": "shr.core",
-  "fqn": "shr.core.CodeableConcept",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.CodeableConcept",
   "isEntry": false,
   "isAbstract": false,
   "description": "A set of codes drawn from different coding systems, representing the same concept.",
   "fields": [
     {
-      "fqn": "shr.core.Coding",
+      "fqn": "obf.datatype.Coding",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0
       }
     },
     {
-      "fqn": "shr.core.DisplayText",
+      "fqn": "obf.datatype.DisplayText",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-Coding.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Coding.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Coding",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Coding",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Coding",
   "isEntry": false,
   "isAbstract": false,
   "description": "Coding of a concept, drawn from a controlled vocabulary. Includes the vocabulary and version, if applicable. May include a display text, and a descriptor expressing the intended interpretation of the code.",
@@ -22,7 +22,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.CodeSystem",
+      "fqn": "obf.datatype.CodeSystem",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -30,7 +30,7 @@
       }
     },
     {
-      "fqn": "shr.core.CodeSystemVersion",
+      "fqn": "obf.datatype.CodeSystemVersion",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -38,7 +38,7 @@
       }
     },
     {
-      "fqn": "shr.core.DisplayText",
+      "fqn": "obf.datatype.DisplayText",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-Comparator.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Comparator.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Comparator",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Comparator",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Comparator",
   "isEntry": false,
   "isAbstract": false,
   "value": {
@@ -16,7 +16,7 @@
       "valueSet": {
         "uri": "http://hl7.org/fhir/ValueSet/quantity-comparator",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.Comparator"
+        "lastModifiedBy": "obf.datatype.Comparator"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-ContactDetail.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-ContactDetail.json
@@ -1,14 +1,14 @@
 {
   "fileType": "DataElement",
   "name": "ContactDetail",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ContactDetail",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ContactDetail",
   "isEntry": false,
   "isAbstract": false,
   "description": "Describes an individual and how to reach them.",
   "fields": [
     {
-      "fqn": "shr.core.HumanName",
+      "fqn": "obf.datatype.HumanName",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -16,7 +16,7 @@
       }
     },
     {
-      "fqn": "shr.core.ContactPoint",
+      "fqn": "obf.datatype.ContactPoint",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0

--- a/test/fixtures/cimcore/shr-core/shr-core-ContactPoint.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-ContactPoint.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "ContactPoint",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ContactPoint",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ContactPoint",
   "isEntry": false,
   "isAbstract": false,
   "description": "An electronic means of contacting an organization or individual.",
@@ -14,7 +14,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.TelecomNumberOrAddress",
+      "fqn": "obf.datatype.TelecomNumberOrAddress",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -30,18 +30,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/contact-point-system",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.ContactPoint"
+              "lastModifiedBy": "obf.datatype.ContactPoint"
             }
           }
         }
       }
     },
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -49,18 +49,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/contact-point-use",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.ContactPoint"
+              "lastModifiedBy": "obf.datatype.ContactPoint"
             }
           }
         }
       }
     },
     {
-      "fqn": "shr.core.PriorityRank",
+      "fqn": "obf.datatype.PriorityRank",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-ContentType.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-ContentType.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "ContentType",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ContentType",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ContentType",
   "isEntry": false,
   "isAbstract": false,
   "description": "Mime type of the content, with charset etc.",

--- a/test/fixtures/cimcore/shr-core/shr-core-CorrectionFactor.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-CorrectionFactor.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "CorrectionFactor",
-  "namespace": "shr.core",
-  "fqn": "shr.core.CorrectionFactor",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.CorrectionFactor",
   "isEntry": false,
   "isAbstract": false,
   "description": "A correction factor that is applied to the sampled data points before they are added to the origin.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Count.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Count.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Count",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Count",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Count",
   "isEntry": false,
   "isAbstract": false,
   "description": "The number of items (0 or more), as an integer.",

--- a/test/fixtures/cimcore/shr-core/shr-core-CountPerInterval.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-CountPerInterval.json
@@ -1,14 +1,14 @@
 {
   "fileType": "DataElement",
   "name": "CountPerInterval",
-  "namespace": "shr.core",
-  "fqn": "shr.core.CountPerInterval",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.CountPerInterval",
   "isEntry": false,
   "isAbstract": false,
   "description": "How many times the event should take place during one recurrence interval, for example, to specify 3-4 times per day, the CountPerInterval should be 3 to 4.",
   "fields": [
     {
-      "fqn": "shr.core.MinCount",
+      "fqn": "obf.datatype.MinCount",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -16,7 +16,7 @@
       }
     },
     {
-      "fqn": "shr.core.MaxCount",
+      "fqn": "obf.datatype.MaxCount",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-Country.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Country.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Country",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Country",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Country",
   "isEntry": false,
   "isAbstract": false,
   "description": "Country - a nation as commonly understood or generally accepted, expressed in ISO 3166 Alpha-2 (2-letter) codes.",
@@ -13,10 +13,10 @@
     }
   ],
   "hierarchy": [
-    "shr.core.GeopoliticalLocation"
+    "obf.datatype.GeopoliticalLocation"
   ],
   "basedOn": [
-    "shr.core.GeopoliticalLocation"
+    "obf.datatype.GeopoliticalLocation"
   ],
   "value": {
     "fqn": "string",

--- a/test/fixtures/cimcore/shr-core/shr-core-CreationTime.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-CreationTime.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "CreationTime",
-  "namespace": "shr.core",
-  "fqn": "shr.core.CreationTime",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.CreationTime",
   "isEntry": false,
   "isAbstract": false,
   "description": "The point in time when the information was recorded in the system of record.",

--- a/test/fixtures/cimcore/shr-core/shr-core-DailyLifeEvent.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-DailyLifeEvent.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "DailyLifeEvent",
-  "namespace": "shr.core",
-  "fqn": "shr.core.DailyLifeEvent",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.DailyLifeEvent",
   "isEntry": false,
   "isAbstract": false,
   "description": "A quotidian landmark, such as rising, mealtime, or bedtime, when an event should take place.",
@@ -17,7 +17,7 @@
       "valueSet": {
         "uri": "http://hl7.org/fhir/ValueSet/event-timing",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.DailyLifeEvent"
+        "lastModifiedBy": "obf.datatype.DailyLifeEvent"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-DayOfWeek.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-DayOfWeek.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "DayOfWeek",
-  "namespace": "shr.core",
-  "fqn": "shr.core.DayOfWeek",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.DayOfWeek",
   "isEntry": false,
   "isAbstract": false,
   "description": "A day of the week that the pattern should take place.",
@@ -17,7 +17,7 @@
       "valueSet": {
         "uri": "http://hl7.org/fhir/ValueSet/days-of-week",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.DayOfWeek"
+        "lastModifiedBy": "obf.datatype.DayOfWeek"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-Denominator.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Denominator.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Denominator",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Denominator",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Denominator",
   "isEntry": false,
   "isAbstract": false,
   "description": "The divisor of a fraction.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-Depth.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Depth.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Depth",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Depth",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Depth",
   "isEntry": false,
   "isAbstract": false,
   "description": "The extent downward or inward; the perpendicular measurement from the surface downward to determine deepness.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,16 +21,16 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {
                   "system": "http://unitsofmeasure.org",
                   "code": "TBD"
                 },
-                "lastModifiedBy": "shr.core.Depth"
+                "lastModifiedBy": "obf.datatype.Depth"
               }
             }
           }

--- a/test/fixtures/cimcore/shr-core/shr-core-Details.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Details.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Details",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Details",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Details",
   "isEntry": false,
   "isAbstract": false,
   "description": "An text note containing additional details, explanation, description, comment, or summarization. Details can discuss, support, explain changes to, or dispute information.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Dimensions.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Dimensions.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Dimensions",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Dimensions",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Dimensions",
   "isEntry": false,
   "isAbstract": false,
   "description": "The number of sample points at each time point. If this value is greater than one, then the dimensions will be interlaced - all the sample points for a point in time will be recorded at once.",

--- a/test/fixtures/cimcore/shr-core/shr-core-DisplayText.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-DisplayText.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "DisplayText",
-  "namespace": "shr.core",
-  "fqn": "shr.core.DisplayText",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.DisplayText",
   "isEntry": false,
   "isAbstract": false,
   "description": "A string meant for reading by a person, for example, accompanying a code.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Distance.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Distance.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Distance",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Distance",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Distance",
   "isEntry": false,
   "isAbstract": false,
   "description": "The measure of space separating two objects or points.",
@@ -13,10 +13,10 @@
     }
   ],
   "hierarchy": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "basedOn": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "value": {
     "fqn": "decimal",
@@ -27,12 +27,12 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.Quantity"
+      "from": "obf.datatype.Quantity"
     }
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -40,11 +40,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -52,28 +52,28 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/UnitsOfLengthVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/UnitsOfLengthVS",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Distance"
+              "lastModifiedBy": "obf.datatype.Distance"
             }
           }
         }
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       },
       "constraintHistory": {
         "valueSet": [
           {
             "constraint": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/UnitsOfLengthVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/UnitsOfLengthVS",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Distance"
+              "lastModifiedBy": "obf.datatype.Distance"
             },
-            "source": "shr.core.Distance"
+            "source": "obf.datatype.Distance"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-District.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-District.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "District",
-  "namespace": "shr.core",
-  "fqn": "shr.core.District",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.District",
   "isEntry": false,
   "isAbstract": false,
   "description": "The name of the administrative area at a level below that of a state but above that of a city or town. In the US, a county. Outside the US, a district or the equivalent. (Source: HL7 FHIR).",
@@ -13,10 +13,10 @@
     }
   ],
   "hierarchy": [
-    "shr.core.GeopoliticalLocation"
+    "obf.datatype.GeopoliticalLocation"
   ],
   "basedOn": [
-    "shr.core.GeopoliticalLocation"
+    "obf.datatype.GeopoliticalLocation"
   ],
   "value": {
     "fqn": "string",

--- a/test/fixtures/cimcore/shr-core/shr-core-Duration.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Duration.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Duration",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Duration",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Duration",
   "isEntry": false,
   "isAbstract": false,
   "description": "The length of time that something continues.",
@@ -13,10 +13,10 @@
     }
   ],
   "hierarchy": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "basedOn": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "value": {
     "fqn": "decimal",
@@ -27,12 +27,12 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.Quantity"
+      "from": "obf.datatype.Quantity"
     }
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -40,11 +40,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -52,28 +52,28 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/TimeUnitOfMeasureVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/TimeUnitOfMeasureVS",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Duration"
+              "lastModifiedBy": "obf.datatype.Duration"
             }
           }
         }
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       },
       "constraintHistory": {
         "valueSet": [
           {
             "constraint": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/TimeUnitOfMeasureVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/TimeUnitOfMeasureVS",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Duration"
+              "lastModifiedBy": "obf.datatype.Duration"
             },
-            "source": "shr.core.Duration"
+            "source": "obf.datatype.Duration"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-DurationRange.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-DurationRange.json
@@ -1,14 +1,14 @@
 {
   "fileType": "DataElement",
   "name": "DurationRange",
-  "namespace": "shr.core",
-  "fqn": "shr.core.DurationRange",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.DurationRange",
   "isEntry": false,
   "isAbstract": false,
   "description": "A range of durations.",
   "fields": [
     {
-      "fqn": "shr.core.LowerBound",
+      "fqn": "obf.datatype.LowerBound",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -16,18 +16,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "type": {
-              "fqn": "shr.core.Duration",
+              "fqn": "obf.datatype.Duration",
               "onValue": false,
-              "lastModifiedBy": "shr.core.DurationRange"
+              "lastModifiedBy": "obf.datatype.DurationRange"
             }
           }
         }
       }
     },
     {
-      "fqn": "shr.core.UpperBound",
+      "fqn": "obf.datatype.UpperBound",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -35,11 +35,11 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "type": {
-              "fqn": "shr.core.Duration",
+              "fqn": "obf.datatype.Duration",
               "onValue": false,
-              "lastModifiedBy": "shr.core.DurationRange"
+              "lastModifiedBy": "obf.datatype.DurationRange"
             }
           }
         }

--- a/test/fixtures/cimcore/shr-core/shr-core-EffectiveDate.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-EffectiveDate.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "EffectiveDate",
-  "namespace": "shr.core",
-  "fqn": "shr.core.EffectiveDate",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.EffectiveDate",
   "isEntry": false,
   "isAbstract": false,
   "description": "The date when something is to take effect.",

--- a/test/fixtures/cimcore/shr-core/shr-core-EffectiveTimePeriod.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-EffectiveTimePeriod.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "EffectiveTimePeriod",
-  "namespace": "shr.core",
-  "fqn": "shr.core.EffectiveTimePeriod",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.EffectiveTimePeriod",
   "isEntry": false,
   "isAbstract": false,
   "description": "The date and time span for which something is active, valid, or in force.",
@@ -13,14 +13,14 @@
     }
   ],
   "hierarchy": [
-    "shr.core.TimePeriod"
+    "obf.datatype.TimePeriod"
   ],
   "basedOn": [
-    "shr.core.TimePeriod"
+    "obf.datatype.TimePeriod"
   ],
   "fields": [
     {
-      "fqn": "shr.core.TimePeriodStart",
+      "fqn": "obf.datatype.TimePeriodStart",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -28,11 +28,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.TimePeriod"
+        "from": "obf.datatype.TimePeriod"
       }
     },
     {
-      "fqn": "shr.core.TimePeriodEnd",
+      "fqn": "obf.datatype.TimePeriodEnd",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -40,7 +40,7 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.TimePeriod"
+        "from": "obf.datatype.TimePeriod"
       }
     }
   ]

--- a/test/fixtures/cimcore/shr-core/shr-core-EmbeddedContent.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-EmbeddedContent.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "EmbeddedContent",
-  "namespace": "shr.core",
-  "fqn": "shr.core.EmbeddedContent",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.EmbeddedContent",
   "isEntry": false,
   "isAbstract": false,
   "description": "Abstract class defining the common metadata of all types of encapsulated data, such as images."

--- a/test/fixtures/cimcore/shr-core/shr-core-EventDuration.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-EventDuration.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "EventDuration",
-  "namespace": "shr.core",
-  "fqn": "shr.core.EventDuration",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.EventDuration",
   "isEntry": false,
   "isAbstract": false,
   "description": "The length of the recurring event.",
   "value": {
-    "fqn": "shr.core.DurationRange",
+    "fqn": "obf.datatype.DurationRange",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-Formalism.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Formalism.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "Formalism",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Formalism",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Formalism",
   "isEntry": false,
   "isAbstract": false,
   "description": "The system of formal syntax or interpretation associated with parsable content.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-Frequency.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Frequency.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Frequency",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Frequency",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Frequency",
   "isEntry": false,
   "isAbstract": false,
   "description": "How many occurrences of an event per unit of time.",
@@ -13,14 +13,14 @@
     }
   ],
   "hierarchy": [
-    "shr.core.Ratio"
+    "obf.datatype.Ratio"
   ],
   "basedOn": [
-    "shr.core.Ratio"
+    "obf.datatype.Ratio"
   ],
   "fields": [
     {
-      "fqn": "shr.core.Numerator",
+      "fqn": "obf.datatype.Numerator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -28,18 +28,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "subpaths": {
-              "shr.core.Units": {
+              "obf.datatype.Units": {
                 "subpaths": {
-                  "shr.core.Coding": {
+                  "obf.datatype.Coding": {
                     "fixedValue": {
                       "type": "code",
                       "value": {
                         "system": "http://unitsofmeasure.org",
                         "code": "1"
                       },
-                      "lastModifiedBy": "shr.core.Frequency"
+                      "lastModifiedBy": "obf.datatype.Frequency"
                     }
                   }
                 }
@@ -50,7 +50,7 @@
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Ratio"
+        "from": "obf.datatype.Ratio"
       },
       "constraintHistory": {
         "code": [
@@ -61,15 +61,15 @@
                 "system": "http://unitsofmeasure.org",
                 "code": "1"
               },
-              "lastModifiedBy": "shr.core.Frequency"
+              "lastModifiedBy": "obf.datatype.Frequency"
             },
-            "source": "shr.core.Frequency"
+            "source": "obf.datatype.Frequency"
           }
         ]
       }
     },
     {
-      "fqn": "shr.core.Denominator",
+      "fqn": "obf.datatype.Denominator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -77,15 +77,15 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "subpaths": {
-              "shr.core.Units": {
+              "obf.datatype.Units": {
                 "subpaths": {
-                  "shr.core.Coding": {
+                  "obf.datatype.Coding": {
                     "valueSet": {
                       "uri": "http://hl7.org/fhir/ValueSet/units-of-time",
                       "bindingStrength": "REQUIRED",
-                      "lastModifiedBy": "shr.core.Frequency"
+                      "lastModifiedBy": "obf.datatype.Frequency"
                     }
                   }
                 }
@@ -96,7 +96,7 @@
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Ratio"
+        "from": "obf.datatype.Ratio"
       },
       "constraintHistory": {
         "valueSet": [
@@ -104,9 +104,9 @@
             "constraint": {
               "uri": "http://hl7.org/fhir/ValueSet/units-of-time",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Frequency"
+              "lastModifiedBy": "obf.datatype.Frequency"
             },
-            "source": "shr.core.Frequency"
+            "source": "obf.datatype.Frequency"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-GeopoliticalLocation.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-GeopoliticalLocation.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "GeopoliticalLocation",
-  "namespace": "shr.core",
-  "fqn": "shr.core.GeopoliticalLocation",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.GeopoliticalLocation",
   "isEntry": false,
   "isAbstract": false,
   "description": "The countries of the world and major geopolitical subregions, such as US states.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Geoposition.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Geoposition.json
@@ -1,14 +1,14 @@
 {
   "fileType": "DataElement",
   "name": "Geoposition",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Geoposition",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Geoposition",
   "isEntry": false,
   "isAbstract": false,
   "description": "The location on the surface of the Earth, described by a latitude and longitude (and optional altitude).",
   "fields": [
     {
-      "fqn": "shr.core.Latitude",
+      "fqn": "obf.datatype.Latitude",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -16,7 +16,7 @@
       }
     },
     {
-      "fqn": "shr.core.Longitude",
+      "fqn": "obf.datatype.Longitude",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -24,7 +24,7 @@
       }
     },
     {
-      "fqn": "shr.core.Altitude",
+      "fqn": "obf.datatype.Altitude",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-GestationalAge.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-GestationalAge.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "GestationalAge",
-  "namespace": "shr.core",
-  "fqn": "shr.core.GestationalAge",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.GestationalAge",
   "isEntry": false,
   "isAbstract": false,
   "description": "The age of the embryo or fetus. This may be assessed by medical history, physical examination, early immunologic pregnancy tests, radiography, ultrasonography, and amniotic fluid analysis.",
@@ -13,11 +13,11 @@
     }
   ],
   "hierarchy": [
-    "shr.core.Quantity",
-    "shr.core.Age"
+    "obf.datatype.Quantity",
+    "obf.datatype.Age"
   ],
   "basedOn": [
-    "shr.core.Age"
+    "obf.datatype.Age"
   ],
   "value": {
     "fqn": "decimal",
@@ -28,12 +28,12 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.Quantity"
+      "from": "obf.datatype.Quantity"
     }
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -41,11 +41,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -53,18 +53,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/units-of-time",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Age"
+              "lastModifiedBy": "obf.datatype.Age"
             }
           }
         }
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       },
       "constraintHistory": {
         "valueSet": [
@@ -73,7 +73,7 @@
               "uri": "http://hl7.org/fhir/ValueSet/units-of-time",
               "bindingStrength": "REQUIRED"
             },
-            "source": "shr.core.Age"
+            "source": "obf.datatype.Age"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-GestationalTemporalContext.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-GestationalTemporalContext.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "GestationalTemporalContext",
-  "namespace": "shr.core",
-  "fqn": "shr.core.GestationalTemporalContext",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.GestationalTemporalContext",
   "isEntry": false,
   "isAbstract": false,
   "description": "A named gestational time period, or a gestational age.",
@@ -14,11 +14,11 @@
     },
     "options": [
       {
-        "fqn": "shr.core.GestationalAge",
+        "fqn": "obf.datatype.GestationalAge",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.GestationalTimePeriod",
+        "fqn": "obf.datatype.GestationalTimePeriod",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/shr-core/shr-core-GestationalTimePeriod.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-GestationalTimePeriod.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "GestationalTimePeriod",
-  "namespace": "shr.core",
-  "fqn": "shr.core.GestationalTimePeriod",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.GestationalTimePeriod",
   "isEntry": false,
   "isAbstract": false,
   "description": "A time relative to a pregnancy or childbirth event.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -17,7 +17,7 @@
       "valueSet": {
         "uri": "urn:tbd:GestationalTimePeriodVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.GestationalTimePeriod"
+        "lastModifiedBy": "obf.datatype.GestationalTimePeriod"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-Hash.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Hash.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Hash",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Hash",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Hash",
   "isEntry": false,
   "isAbstract": false,
   "description": "A hash code of the data (sha-1, base64ed)",

--- a/test/fixtures/cimcore/shr-core/shr-core-HumanName.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-HumanName.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "HumanName",
-  "namespace": "shr.core",
-  "fqn": "shr.core.HumanName",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.HumanName",
   "isEntry": false,
   "isAbstract": false,
   "description": "The CIMI person name, constrained to map correctly to FHIR.",
@@ -33,7 +33,7 @@
       }
     },
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -52,7 +52,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/name-use",
               "bindingStrength": "REQUIRED",
@@ -87,7 +87,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -144,7 +144,7 @@
             "min": 0
           },
           {
-            "source": "shr.core.HumanName",
+            "source": "obf.datatype.HumanName",
             "min": 0,
             "max": 0
           }
@@ -160,9 +160,9 @@
             "constraint": {
               "min": 0,
               "max": 0,
-              "lastModifiedBy": "shr.core.HumanName"
+              "lastModifiedBy": "obf.datatype.HumanName"
             },
-            "source": "shr.core.HumanName"
+            "source": "obf.datatype.HumanName"
           }
         ]
       }
@@ -179,7 +179,7 @@
             "min": 0
           },
           {
-            "source": "shr.core.HumanName",
+            "source": "obf.datatype.HumanName",
             "min": 0,
             "max": 1
           }
@@ -195,9 +195,9 @@
             "constraint": {
               "min": 0,
               "max": 1,
-              "lastModifiedBy": "shr.core.HumanName"
+              "lastModifiedBy": "obf.datatype.HumanName"
             },
-            "source": "shr.core.HumanName"
+            "source": "obf.datatype.HumanName"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-IntegerQuantity.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-IntegerQuantity.json
@@ -1,16 +1,16 @@
 {
   "fileType": "DataElement",
   "name": "IntegerQuantity",
-  "namespace": "shr.core",
-  "fqn": "shr.core.IntegerQuantity",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.IntegerQuantity",
   "isEntry": false,
   "isAbstract": false,
   "description": "A Quantity that is an integer.",
   "hierarchy": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "basedOn": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "value": {
     "fqn": "decimal",
@@ -21,12 +21,12 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.Quantity"
+      "from": "obf.datatype.Quantity"
     }
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -34,11 +34,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -46,21 +46,21 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "fixedValue": {
               "type": "code",
               "value": {
                 "system": "http://unitsofmeasure.org",
                 "code": "1"
               },
-              "lastModifiedBy": "shr.core.IntegerQuantity"
+              "lastModifiedBy": "obf.datatype.IntegerQuantity"
             }
           }
         }
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       },
       "constraintHistory": {
         "code": [
@@ -71,9 +71,9 @@
                 "system": "http://unitsofmeasure.org",
                 "code": "1"
               },
-              "lastModifiedBy": "shr.core.IntegerQuantity"
+              "lastModifiedBy": "obf.datatype.IntegerQuantity"
             },
-            "source": "shr.core.IntegerQuantity"
+            "source": "obf.datatype.IntegerQuantity"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-Language.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Language.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Language",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Language",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Language",
   "isEntry": false,
   "isAbstract": false,
   "description": "A human language, spoken or written.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -23,7 +23,7 @@
       "valueSet": {
         "uri": "http://hl7.org/fhir/ValueSet/languages",
         "bindingStrength": "EXTENSIBLE",
-        "lastModifiedBy": "shr.core.Language"
+        "lastModifiedBy": "obf.datatype.Language"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-Latitude.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Latitude.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Latitude",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Latitude",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Latitude",
   "isEntry": false,
   "isAbstract": false,
   "description": "The angular distance north or south between an imaginary line around a heavenly body parallel to its equator and the equator itself. Measured with with WGS84 datum.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Length.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Length.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Length",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Length",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Length",
   "isEntry": false,
   "isAbstract": false,
   "description": "The measurement or linear extent of something from end to end; the greatest dimensions of a body.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,16 +21,16 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {
                   "system": "http://unitsofmeasure.org",
                   "code": "TBD"
                 },
-                "lastModifiedBy": "shr.core.Length"
+                "lastModifiedBy": "obf.datatype.Length"
               }
             }
           }

--- a/test/fixtures/cimcore/shr-core/shr-core-LifeEventOffset.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-LifeEventOffset.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "LifeEventOffset",
-  "namespace": "shr.core",
-  "fqn": "shr.core.LifeEventOffset",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.LifeEventOffset",
   "isEntry": false,
   "isAbstract": false,
   "description": "A time in minutes before or after a given life event, for example, 30 minutes before a meal. Whether this means before or after is carried by the life event code.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Likelihood.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Likelihood.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Likelihood",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Likelihood",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Likelihood",
   "isEntry": false,
   "isAbstract": false,
   "description": "A measure of the expectation of the occurrence of a particular event, as a percentage.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Longitude.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Longitude.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Longitude",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Longitude",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Longitude",
   "isEntry": false,
   "isAbstract": false,
   "description": "An imaginary great circle on the surface of a heavenly body passing through the poles at right angles to the equator. Measured with with WGS84 datum.",

--- a/test/fixtures/cimcore/shr-core/shr-core-LowerBound.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-LowerBound.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "LowerBound",
-  "namespace": "shr.core",
-  "fqn": "shr.core.LowerBound",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.LowerBound",
   "isEntry": false,
   "isAbstract": false,
   "description": "The lower limit on a range",
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-LowerLimit.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-LowerLimit.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "LowerLimit",
-  "namespace": "shr.core",
-  "fqn": "shr.core.LowerLimit",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.LowerLimit",
   "isEntry": false,
   "isAbstract": false,
   "description": "The lower limit of detection of the measured points. This is needed if any of the data points have the value 'L' (lower than detection limit).",

--- a/test/fixtures/cimcore/shr-core/shr-core-MaxCount.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-MaxCount.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "MaxCount",
-  "namespace": "shr.core",
-  "fqn": "shr.core.MaxCount",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.MaxCount",
   "isEntry": false,
   "isAbstract": false,
   "description": "Upper bound on a count.",

--- a/test/fixtures/cimcore/shr-core/shr-core-MillisecondsBetweenSamples.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-MillisecondsBetweenSamples.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "MillisecondsBetweenSamples",
-  "namespace": "shr.core",
-  "fqn": "shr.core.MillisecondsBetweenSamples",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.MillisecondsBetweenSamples",
   "isEntry": false,
   "isAbstract": false,
   "description": "The length of time between sampling times, measured in milliseconds.",

--- a/test/fixtures/cimcore/shr-core/shr-core-MinCount.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-MinCount.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "MinCount",
-  "namespace": "shr.core",
-  "fqn": "shr.core.MinCount",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.MinCount",
   "isEntry": false,
   "isAbstract": false,
   "description": "Lower bound on a count.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Money.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Money.json
@@ -1,16 +1,16 @@
 {
   "fileType": "DataElement",
   "name": "Money",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Money",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Money",
   "isEntry": false,
   "isAbstract": false,
   "description": "Representation of an amount of currency or monetary value.",
   "hierarchy": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "basedOn": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "value": {
     "fqn": "decimal",
@@ -21,12 +21,12 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.Quantity"
+      "from": "obf.datatype.Quantity"
     }
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -34,11 +34,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -46,28 +46,28 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/CurrencyVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/CurrencyVS",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Money"
+              "lastModifiedBy": "obf.datatype.Money"
             }
           }
         }
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       },
       "constraintHistory": {
         "valueSet": [
           {
             "constraint": {
-              "uri": "http://standardhealthrecord.org/shr/core/vs/CurrencyVS",
+              "uri": "http://standardhealthrecord.org/obf/datatype/vs/CurrencyVS",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Money"
+              "lastModifiedBy": "obf.datatype.Money"
             },
-            "source": "shr.core.Money"
+            "source": "obf.datatype.Money"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-NonOccurrenceTimeOrPeriod.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-NonOccurrenceTimeOrPeriod.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "NonOccurrenceTimeOrPeriod",
-  "namespace": "shr.core",
-  "fqn": "shr.core.NonOccurrenceTimeOrPeriod",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.NonOccurrenceTimeOrPeriod",
   "isEntry": false,
   "isAbstract": false,
   "description": "The point in time or span of time in which something did not happen.",
@@ -22,7 +22,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/shr-core/shr-core-NumberOfRepeats.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-NumberOfRepeats.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "NumberOfRepeats",
-  "namespace": "shr.core",
-  "fqn": "shr.core.NumberOfRepeats",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.NumberOfRepeats",
   "isEntry": false,
   "isAbstract": false,
   "description": "How many times the action should be repeated.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Numerator.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Numerator.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Numerator",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Numerator",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Numerator",
   "isEntry": false,
   "isAbstract": false,
   "description": "The dividend of a fraction.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-OccurrenceDuration.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-OccurrenceDuration.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "OccurrenceDuration",
-  "namespace": "shr.core",
-  "fqn": "shr.core.OccurrenceDuration",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.OccurrenceDuration",
   "isEntry": false,
   "isAbstract": false,
   "description": "The length of time in which something happens.",
   "value": {
-    "fqn": "shr.core.Duration",
+    "fqn": "obf.datatype.Duration",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-OccurrencePeriod.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-OccurrencePeriod.json
@@ -1,19 +1,19 @@
 {
   "fileType": "DataElement",
   "name": "OccurrencePeriod",
-  "namespace": "shr.core",
-  "fqn": "shr.core.OccurrencePeriod",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.OccurrencePeriod",
   "isEntry": false,
   "isAbstract": false,
   "description": "The point in time or span of time in which something happens.",
   "hierarchy": [
-    "shr.core.OccurrenceTimeOrPeriod"
+    "obf.datatype.OccurrenceTimeOrPeriod"
   ],
   "basedOn": [
-    "shr.core.OccurrenceTimeOrPeriod"
+    "obf.datatype.OccurrenceTimeOrPeriod"
   ],
   "value": {
-    "fqn": "shr.core.TimePeriod",
+    "fqn": "obf.datatype.TimePeriod",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,7 +21,7 @@
     },
     "inheritance": {
       "status": "overridden",
-      "from": "shr.core.OccurrenceTimeOrPeriod"
+      "from": "obf.datatype.OccurrenceTimeOrPeriod"
     }
   }
 }

--- a/test/fixtures/cimcore/shr-core/shr-core-OccurrenceTime.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-OccurrenceTime.json
@@ -1,16 +1,16 @@
 {
   "fileType": "DataElement",
   "name": "OccurrenceTime",
-  "namespace": "shr.core",
-  "fqn": "shr.core.OccurrenceTime",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.OccurrenceTime",
   "isEntry": false,
   "isAbstract": false,
   "description": "The point in time in which something happens.",
   "hierarchy": [
-    "shr.core.OccurrenceTimeOrPeriod"
+    "obf.datatype.OccurrenceTimeOrPeriod"
   ],
   "basedOn": [
-    "shr.core.OccurrenceTimeOrPeriod"
+    "obf.datatype.OccurrenceTimeOrPeriod"
   ],
   "value": {
     "fqn": "dateTime",
@@ -21,7 +21,7 @@
     },
     "inheritance": {
       "status": "overridden",
-      "from": "shr.core.OccurrenceTimeOrPeriod"
+      "from": "obf.datatype.OccurrenceTimeOrPeriod"
     }
   }
 }

--- a/test/fixtures/cimcore/shr-core/shr-core-OccurrenceTimeOrPeriod.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-OccurrenceTimeOrPeriod.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "OccurrenceTimeOrPeriod",
-  "namespace": "shr.core",
-  "fqn": "shr.core.OccurrenceTimeOrPeriod",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.OccurrenceTimeOrPeriod",
   "isEntry": false,
   "isAbstract": false,
   "description": "The point in time or span of time in which something happens.",
@@ -22,7 +22,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/shr-core/shr-core-Origin.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Origin.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "Origin",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Origin",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Origin",
   "isEntry": false,
   "isAbstract": false,
   "description": "The base quantity that a measured value of zero represents. In addition, this provides the units of the entire measurement series.",
   "value": {
-    "fqn": "shr.core.SimpleQuantity",
+    "fqn": "obf.datatype.SimpleQuantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-ParsableContent.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-ParsableContent.json
@@ -1,16 +1,16 @@
 {
   "fileType": "DataElement",
   "name": "ParsableContent",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ParsableContent",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ParsableContent",
   "isEntry": false,
   "isAbstract": false,
   "description": "A string that follows a formal syntax and can be analyzed and broken into meaningful parts.",
   "hierarchy": [
-    "shr.core.EmbeddedContent"
+    "obf.datatype.EmbeddedContent"
   ],
   "basedOn": [
-    "shr.core.EmbeddedContent"
+    "obf.datatype.EmbeddedContent"
   ],
   "value": {
     "fqn": "string",
@@ -22,7 +22,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Formalism",
+      "fqn": "obf.datatype.Formalism",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-Percentage.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Percentage.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Percentage",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Percentage",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Percentage",
   "isEntry": false,
   "isAbstract": false,
   "description": "A percentage value where 100.0 represents 100%.",
@@ -13,11 +13,11 @@
     }
   ],
   "hierarchy": [
-    "shr.core.Quantity",
-    "shr.core.SimpleQuantity"
+    "obf.datatype.Quantity",
+    "obf.datatype.SimpleQuantity"
   ],
   "basedOn": [
-    "shr.core.SimpleQuantity"
+    "obf.datatype.SimpleQuantity"
   ],
   "value": {
     "fqn": "decimal",
@@ -28,24 +28,24 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.Quantity"
+      "from": "obf.datatype.Quantity"
     }
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
         "max": 0,
         "history": [
           {
-            "source": "shr.core.Quantity",
+            "source": "obf.datatype.Quantity",
             "min": 0,
             "max": 1
           },
           {
-            "source": "shr.core.SimpleQuantity",
+            "source": "obf.datatype.SimpleQuantity",
             "min": 0,
             "max": 0
           }
@@ -53,7 +53,7 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       },
       "constraintHistory": {
         "card": [
@@ -62,13 +62,13 @@
               "min": 0,
               "max": 0
             },
-            "source": "shr.core.SimpleQuantity"
+            "source": "obf.datatype.SimpleQuantity"
           }
         ]
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -76,21 +76,21 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "fixedValue": {
               "type": "code",
               "value": {
                 "system": "http://unitsofmeasure.org",
                 "code": "%"
               },
-              "lastModifiedBy": "shr.core.Percentage"
+              "lastModifiedBy": "obf.datatype.Percentage"
             }
           }
         }
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       },
       "constraintHistory": {
         "code": [
@@ -101,9 +101,9 @@
                 "system": "http://unitsofmeasure.org",
                 "code": "%"
               },
-              "lastModifiedBy": "shr.core.Percentage"
+              "lastModifiedBy": "obf.datatype.Percentage"
             },
-            "source": "shr.core.Percentage"
+            "source": "obf.datatype.Percentage"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-PercentageRange.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-PercentageRange.json
@@ -1,20 +1,20 @@
 {
   "fileType": "DataElement",
   "name": "PercentageRange",
-  "namespace": "shr.core",
-  "fqn": "shr.core.PercentageRange",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.PercentageRange",
   "isEntry": false,
   "isAbstract": false,
   "description": "A range of percentage values.",
   "hierarchy": [
-    "shr.core.Range"
+    "obf.datatype.Range"
   ],
   "basedOn": [
-    "shr.core.Range"
+    "obf.datatype.Range"
   ],
   "fields": [
     {
-      "fqn": "shr.core.LowerBound",
+      "fqn": "obf.datatype.LowerBound",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -22,34 +22,34 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "type": {
-              "fqn": "shr.core.Percentage",
+              "fqn": "obf.datatype.Percentage",
               "onValue": false,
-              "lastModifiedBy": "shr.core.PercentageRange"
+              "lastModifiedBy": "obf.datatype.PercentageRange"
             }
           }
         }
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Range"
+        "from": "obf.datatype.Range"
       },
       "constraintHistory": {
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.Percentage",
+              "fqn": "obf.datatype.Percentage",
               "onValue": false,
-              "lastModifiedBy": "shr.core.PercentageRange"
+              "lastModifiedBy": "obf.datatype.PercentageRange"
             },
-            "source": "shr.core.PercentageRange"
+            "source": "obf.datatype.PercentageRange"
           }
         ]
       }
     },
     {
-      "fqn": "shr.core.UpperBound",
+      "fqn": "obf.datatype.UpperBound",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -57,28 +57,28 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "type": {
-              "fqn": "shr.core.Percentage",
+              "fqn": "obf.datatype.Percentage",
               "onValue": false,
-              "lastModifiedBy": "shr.core.PercentageRange"
+              "lastModifiedBy": "obf.datatype.PercentageRange"
             }
           }
         }
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Range"
+        "from": "obf.datatype.Range"
       },
       "constraintHistory": {
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.Percentage",
+              "fqn": "obf.datatype.Percentage",
               "onValue": false,
-              "lastModifiedBy": "shr.core.PercentageRange"
+              "lastModifiedBy": "obf.datatype.PercentageRange"
             },
-            "source": "shr.core.PercentageRange"
+            "source": "obf.datatype.PercentageRange"
           }
         ]
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-PlainText.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-PlainText.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "PlainText",
-  "namespace": "shr.core",
-  "fqn": "shr.core.PlainText",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.PlainText",
   "isEntry": false,
   "isAbstract": false,
   "description": "A text written in a human language.",
@@ -16,7 +16,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Language",
+      "fqn": "obf.datatype.Language",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-PostalCode.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-PostalCode.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "PostalCode",
-  "namespace": "shr.core",
-  "fqn": "shr.core.PostalCode",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.PostalCode",
   "isEntry": false,
   "isAbstract": false,
   "description": "A sequence of letters and digits used as part of a postal address, often designating a geographic region",

--- a/test/fixtures/cimcore/shr-core/shr-core-PriorityRank.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-PriorityRank.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "PriorityRank",
-  "namespace": "shr.core",
-  "fqn": "shr.core.PriorityRank",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.PriorityRank",
   "isEntry": false,
   "isAbstract": false,
   "description": "An indication of the importance of an action.",
@@ -24,7 +24,7 @@
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.CodeableConcept",
+        "fqn": "obf.datatype.CodeableConcept",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/shr-core/shr-core-Purpose.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Purpose.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "Purpose",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Purpose",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Purpose",
   "isEntry": false,
   "isAbstract": false,
   "description": "Why the item is used.",
   "value": {
-    "fqn": "shr.core.Coding",
+    "fqn": "obf.datatype.Coding",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-QualitativeDateTime.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-QualitativeDateTime.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "QualitativeDateTime",
-  "namespace": "shr.core",
-  "fqn": "shr.core.QualitativeDateTime",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.QualitativeDateTime",
   "isEntry": false,
   "isAbstract": false,
   "description": "A point in time, described qualitatively.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -15,9 +15,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/QualitativeDateTimeVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/QualitativeDateTimeVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.QualitativeDateTime"
+        "lastModifiedBy": "obf.datatype.QualitativeDateTime"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-QualitativeFrequency.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-QualitativeFrequency.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "QualitativeFrequency",
-  "namespace": "shr.core",
-  "fqn": "shr.core.QualitativeFrequency",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.QualitativeFrequency",
   "isEntry": false,
   "isAbstract": false,
   "description": "The frequency of an event, described qualitatively.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -15,9 +15,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/QualitativeFrequencyVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.QualitativeFrequency"
+        "lastModifiedBy": "obf.datatype.QualitativeFrequency"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-QualitativeLikelihood.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-QualitativeLikelihood.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "QualitativeLikelihood",
-  "namespace": "shr.core",
-  "fqn": "shr.core.QualitativeLikelihood",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.QualitativeLikelihood",
   "isEntry": false,
   "isAbstract": false,
   "description": "A qualitative (subjective) likelihood.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -15,9 +15,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/QualitativeLikelihoodVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/QualitativeLikelihoodVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.QualitativeLikelihood"
+        "lastModifiedBy": "obf.datatype.QualitativeLikelihood"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-Quantity.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Quantity.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Quantity",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Quantity",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Quantity",
   "isEntry": false,
   "isAbstract": false,
   "description": "A quantity with units, whose value may be bounded from above or below, as defined in FHIR",
@@ -16,7 +16,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -24,7 +24,7 @@
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-Range.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Range.json
@@ -1,14 +1,14 @@
 {
   "fileType": "DataElement",
   "name": "Range",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Range",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Range",
   "isEntry": false,
   "isAbstract": false,
   "description": "An interval defined by a quantitative upper and/or lower bound. One of the two bounds must be specified, and the lower bound must be less than the upper bound. When Quantities are specified, the units of measure must be the same.",
   "fields": [
     {
-      "fqn": "shr.core.LowerBound",
+      "fqn": "obf.datatype.LowerBound",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -16,18 +16,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "type": {
-              "fqn": "shr.core.SimpleQuantity",
+              "fqn": "obf.datatype.SimpleQuantity",
               "onValue": false,
-              "lastModifiedBy": "shr.core.Range"
+              "lastModifiedBy": "obf.datatype.Range"
             }
           }
         }
       }
     },
     {
-      "fqn": "shr.core.UpperBound",
+      "fqn": "obf.datatype.UpperBound",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -35,11 +35,11 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Quantity": {
+          "obf.datatype.Quantity": {
             "type": {
-              "fqn": "shr.core.SimpleQuantity",
+              "fqn": "obf.datatype.SimpleQuantity",
               "onValue": false,
-              "lastModifiedBy": "shr.core.Range"
+              "lastModifiedBy": "obf.datatype.Range"
             }
           }
         }

--- a/test/fixtures/cimcore/shr-core/shr-core-Ratio.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Ratio.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Ratio",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Ratio",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Ratio",
   "isEntry": false,
   "isAbstract": false,
   "description": "A unit of measurement for the quotient of the amount of one entity to another.",
@@ -14,7 +14,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.Numerator",
+      "fqn": "obf.datatype.Numerator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "fqn": "shr.core.Denominator",
+      "fqn": "obf.datatype.Denominator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-ReceivedTime.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-ReceivedTime.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "ReceivedTime",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ReceivedTime",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ReceivedTime",
   "isEntry": false,
   "isAbstract": false,
   "description": "Time the item was delivered to, or accepted by, the receiving facility or unit.",

--- a/test/fixtures/cimcore/shr-core/shr-core-RecurrenceInterval.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-RecurrenceInterval.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "RecurrenceInterval",
-  "namespace": "shr.core",
-  "fqn": "shr.core.RecurrenceInterval",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.RecurrenceInterval",
   "isEntry": false,
   "isAbstract": false,
   "description": "The period of time after which the pattern repeats, for example, each day. To specify an event should take place every other Monday, the recurrence interval should be two weeks, and DayOfWeek should be Monday.",
   "value": {
-    "fqn": "shr.core.Duration",
+    "fqn": "obf.datatype.Duration",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-RecurrencePattern.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-RecurrencePattern.json
@@ -1,14 +1,14 @@
 {
   "fileType": "DataElement",
   "name": "RecurrencePattern",
-  "namespace": "shr.core",
-  "fqn": "shr.core.RecurrencePattern",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.RecurrencePattern",
   "isEntry": false,
   "isAbstract": false,
   "description": "A set of rules that describe when a recurring event is scheduled.",
   "fields": [
     {
-      "fqn": "shr.core.RecurrenceInterval",
+      "fqn": "obf.datatype.RecurrenceInterval",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -16,28 +16,28 @@
       }
     },
     {
-      "fqn": "shr.core.DayOfWeek",
+      "fqn": "obf.datatype.DayOfWeek",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0
       }
     },
     {
-      "fqn": "shr.core.TimeOfDay",
+      "fqn": "obf.datatype.TimeOfDay",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0
       }
     },
     {
-      "fqn": "shr.core.DailyLifeEvent",
+      "fqn": "obf.datatype.DailyLifeEvent",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0
       }
     },
     {
-      "fqn": "shr.core.LifeEventOffset",
+      "fqn": "obf.datatype.LifeEventOffset",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -45,7 +45,7 @@
       }
     },
     {
-      "fqn": "shr.core.CountPerInterval",
+      "fqn": "obf.datatype.CountPerInterval",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-RecurrenceRange.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-RecurrenceRange.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "RecurrenceRange",
-  "namespace": "shr.core",
-  "fqn": "shr.core.RecurrenceRange",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.RecurrenceRange",
   "isEntry": false,
   "isAbstract": false,
   "description": "The start and end of the overall recurrence pattern in terms of dates/times or in terms of number of repeats. Could also be an event, such as when all doses are taken.",
@@ -14,11 +14,11 @@
     },
     "options": [
       {
-        "fqn": "shr.core.TimePeriod",
+        "fqn": "obf.datatype.TimePeriod",
         "valueType": "IdentifiableValue"
       },
       {
-        "fqn": "shr.core.NumberOfRepeats",
+        "fqn": "obf.datatype.NumberOfRepeats",
         "valueType": "IdentifiableValue"
       }
     ]

--- a/test/fixtures/cimcore/shr-core/shr-core-ResourceLocation.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-ResourceLocation.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "ResourceLocation",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ResourceLocation",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ResourceLocation",
   "isEntry": false,
   "isAbstract": false,
   "description": "URI where data can be found.",

--- a/test/fixtures/cimcore/shr-core/shr-core-ResourceSize.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-ResourceSize.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "ResourceSize",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ResourceSize",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ResourceSize",
   "isEntry": false,
   "isAbstract": false,
   "description": "Number of bytes of content in the resource (if url provided)",

--- a/test/fixtures/cimcore/shr-core/shr-core-SampledData.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-SampledData.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "SampledData",
-  "namespace": "shr.core",
-  "fqn": "shr.core.SampledData",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.SampledData",
   "isEntry": false,
   "isAbstract": false,
   "description": "Data that comes from a series of measurements taken by a device, which may have upper and lower limits. The data type also supports more than one dimension in the data.",
@@ -16,7 +16,7 @@
   },
   "fields": [
     {
-      "fqn": "shr.core.Origin",
+      "fqn": "obf.datatype.Origin",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -24,7 +24,7 @@
       }
     },
     {
-      "fqn": "shr.core.MillisecondsBetweenSamples",
+      "fqn": "obf.datatype.MillisecondsBetweenSamples",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -32,7 +32,7 @@
       }
     },
     {
-      "fqn": "shr.core.CorrectionFactor",
+      "fqn": "obf.datatype.CorrectionFactor",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -40,7 +40,7 @@
       }
     },
     {
-      "fqn": "shr.core.LowerLimit",
+      "fqn": "obf.datatype.LowerLimit",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -48,7 +48,7 @@
       }
     },
     {
-      "fqn": "shr.core.UpperLimit",
+      "fqn": "obf.datatype.UpperLimit",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -56,7 +56,7 @@
       }
     },
     {
-      "fqn": "shr.core.Dimensions",
+      "fqn": "obf.datatype.Dimensions",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-SemiquantDuration.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-SemiquantDuration.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "SemiquantDuration",
-  "namespace": "shr.core",
-  "fqn": "shr.core.SemiquantDuration",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.SemiquantDuration",
   "isEntry": false,
   "isAbstract": false,
   "description": "The duration of an event, described semi-quantitatively.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -15,9 +15,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/SemiquantitativeDurationVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/SemiquantitativeDurationVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.SemiquantDuration"
+        "lastModifiedBy": "obf.datatype.SemiquantDuration"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-SemiquantFrequency.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-SemiquantFrequency.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "SemiquantFrequency",
-  "namespace": "shr.core",
-  "fqn": "shr.core.SemiquantFrequency",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.SemiquantFrequency",
   "isEntry": false,
   "isAbstract": false,
   "description": "The frequency of an event, described semi-quantitatively.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -15,9 +15,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/SemiquantitativeFrequencyVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/SemiquantitativeFrequencyVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.SemiquantFrequency"
+        "lastModifiedBy": "obf.datatype.SemiquantFrequency"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-Setting.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Setting.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "Setting",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Setting",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Setting",
   "isEntry": false,
   "isAbstract": false,
   "description": "Description of the place or type of surroundings where something is positioned or where an event takes place.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -15,9 +15,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/SettingVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/SettingVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.Setting"
+        "lastModifiedBy": "obf.datatype.Setting"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-SimpleQuantity.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-SimpleQuantity.json
@@ -1,16 +1,16 @@
 {
   "fileType": "DataElement",
   "name": "SimpleQuantity",
-  "namespace": "shr.core",
-  "fqn": "shr.core.SimpleQuantity",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.SimpleQuantity",
   "isEntry": false,
   "isAbstract": false,
   "description": "A quantity where the comparator is not used, as defined in FHIR",
   "hierarchy": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "basedOn": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "value": {
     "fqn": "decimal",
@@ -21,24 +21,24 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.Quantity"
+      "from": "obf.datatype.Quantity"
     }
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
         "max": 0,
         "history": [
           {
-            "source": "shr.core.Quantity",
+            "source": "obf.datatype.Quantity",
             "min": 0,
             "max": 1
           },
           {
-            "source": "shr.core.SimpleQuantity",
+            "source": "obf.datatype.SimpleQuantity",
             "min": 0,
             "max": 0
           }
@@ -46,7 +46,7 @@
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       },
       "constraintHistory": {
         "card": [
@@ -54,15 +54,15 @@
             "constraint": {
               "min": 0,
               "max": 0,
-              "lastModifiedBy": "shr.core.SimpleQuantity"
+              "lastModifiedBy": "obf.datatype.SimpleQuantity"
             },
-            "source": "shr.core.SimpleQuantity"
+            "source": "obf.datatype.SimpleQuantity"
           }
         ]
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -70,7 +70,7 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       }
     }
   ]

--- a/test/fixtures/cimcore/shr-core/shr-core-State.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-State.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "State",
-  "namespace": "shr.core",
-  "fqn": "shr.core.State",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.State",
   "isEntry": false,
   "isAbstract": false,
   "description": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (i.e. US 2 letter state codes). (Source: HL7 FHIR).",
@@ -13,10 +13,10 @@
     }
   ],
   "hierarchy": [
-    "shr.core.GeopoliticalLocation"
+    "obf.datatype.GeopoliticalLocation"
   ],
   "basedOn": [
-    "shr.core.GeopoliticalLocation"
+    "obf.datatype.GeopoliticalLocation"
   ],
   "value": {
     "fqn": "string",

--- a/test/fixtures/cimcore/shr-core/shr-core-Statistic.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Statistic.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Statistic",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Statistic",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Statistic",
   "isEntry": false,
   "isAbstract": false,
   "description": "A quantity that represents a statistic, e.g. maximum, minimum, mean, median, etc.",
@@ -13,10 +13,10 @@
     }
   ],
   "hierarchy": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "basedOn": [
-    "shr.core.Quantity"
+    "obf.datatype.Quantity"
   ],
   "value": {
     "fqn": "decimal",
@@ -27,12 +27,12 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.Quantity"
+      "from": "obf.datatype.Quantity"
     }
   },
   "fields": [
     {
-      "fqn": "shr.core.Comparator",
+      "fqn": "obf.datatype.Comparator",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -40,11 +40,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       }
     },
     {
-      "fqn": "shr.core.Units",
+      "fqn": "obf.datatype.Units",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -52,11 +52,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Quantity"
+        "from": "obf.datatype.Quantity"
       }
     },
     {
-      "fqn": "shr.core.StatisticType",
+      "fqn": "obf.datatype.StatisticType",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-StatisticType.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-StatisticType.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "StatisticType",
-  "namespace": "shr.core",
-  "fqn": "shr.core.StatisticType",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.StatisticType",
   "isEntry": false,
   "isAbstract": false,
   "description": "The type of statistic that is represented by the value.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -15,9 +15,9 @@
     },
     "constraints": {
       "valueSet": {
-        "uri": "http://standardhealthrecord.org/shr/core/vs/StatisticTypeVS",
+        "uri": "http://standardhealthrecord.org/obf/datatype/vs/StatisticTypeVS",
         "bindingStrength": "REQUIRED",
-        "lastModifiedBy": "shr.core.StatisticType"
+        "lastModifiedBy": "obf.datatype.StatisticType"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-TelecomNumberOrAddress.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-TelecomNumberOrAddress.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "TelecomNumberOrAddress",
-  "namespace": "shr.core",
-  "fqn": "shr.core.TelecomNumberOrAddress",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.TelecomNumberOrAddress",
   "isEntry": false,
   "isAbstract": false,
   "description": "A user name or other identifier on a telecommunication network, such as a telephone number (including country code and extension, if necessary), email address, or SkypeID.",

--- a/test/fixtures/cimcore/shr-core/shr-core-TimeOfDay.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-TimeOfDay.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "TimeOfDay",
-  "namespace": "shr.core",
-  "fqn": "shr.core.TimeOfDay",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.TimeOfDay",
   "isEntry": false,
   "isAbstract": false,
   "description": "Time of day the event should take place on the designated day(s). TimeOfDay should only be specified if the RecurrenceInterval and/or DayOfWeek establishes the day when the event should take place.",

--- a/test/fixtures/cimcore/shr-core/shr-core-TimePeriod.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-TimePeriod.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "TimePeriod",
-  "namespace": "shr.core",
-  "fqn": "shr.core.TimePeriod",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.TimePeriod",
   "isEntry": false,
   "isAbstract": false,
   "description": "A period of time defined by a start and end time, date, or year. If the start element is missing, the start of the period is not known. If the end element is missing, it means that the period is ongoing, or the start may be in the past, and the end date in the future, which means that period is expected/planned to end at the specified time. The end value includes any matching date/time. For example, the period 2011-05-23 to 2011-05-27 includes all the times from the start of the 23rd May through to the end of the 27th of May.",
@@ -14,7 +14,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.TimePeriodStart",
+      "fqn": "obf.datatype.TimePeriodStart",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "fqn": "shr.core.TimePeriodEnd",
+      "fqn": "obf.datatype.TimePeriodEnd",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-TimePeriodEnd.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-TimePeriodEnd.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "TimePeriodEnd",
-  "namespace": "shr.core",
-  "fqn": "shr.core.TimePeriodEnd",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.TimePeriodEnd",
   "isEntry": false,
   "isAbstract": false,
   "description": "The time at which something is to end or did end. Boundary is considered inclusive.",

--- a/test/fixtures/cimcore/shr-core/shr-core-TimePeriodStart.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-TimePeriodStart.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "TimePeriodStart",
-  "namespace": "shr.core",
-  "fqn": "shr.core.TimePeriodStart",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.TimePeriodStart",
   "isEntry": false,
   "isAbstract": false,
   "description": "The time at which something is to take effect, start, or did start. Boundary is considered inclusive.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Timing.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Timing.json
@@ -1,21 +1,21 @@
 {
   "fileType": "DataElement",
   "name": "Timing",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Timing",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Timing",
   "isEntry": false,
   "isAbstract": false,
   "description": "A timing schedule that specifies an event that may occur multiple times. Timing offers a choice of multiple OccurrenceTime (used is used to specify specific times), or recurrence patterns.",
   "fields": [
     {
-      "fqn": "shr.core.OccurrenceTime",
+      "fqn": "obf.datatype.OccurrenceTime",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0
       }
     },
     {
-      "fqn": "shr.core.TimingCode",
+      "fqn": "obf.datatype.TimingCode",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "fqn": "shr.core.EventDuration",
+      "fqn": "obf.datatype.EventDuration",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -31,7 +31,7 @@
       }
     },
     {
-      "fqn": "shr.core.RecurrencePattern",
+      "fqn": "obf.datatype.RecurrencePattern",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -39,7 +39,7 @@
       }
     },
     {
-      "fqn": "shr.core.RecurrenceRange",
+      "fqn": "obf.datatype.RecurrenceRange",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-core/shr-core-TimingCode.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-TimingCode.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "TimingCode",
-  "namespace": "shr.core",
-  "fqn": "shr.core.TimingCode",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.TimingCode",
   "isEntry": false,
   "isAbstract": false,
   "description": "A code for the timing schedule. Some codes such as BID are ubiquitous, but many institutions define their own additional codes. If a code is provided, the code is understood to be a complete statement of whatever is specified in the structured timing data, and either the code or the data may be used to interpret the Timing, with the exception that .repeat.bounds still applies over the code (and is not contained in the code).",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -17,7 +17,7 @@
       "valueSet": {
         "uri": "http://hl7.org/fhir/ValueSet/timing-abbreviation",
         "bindingStrength": "EXTENSIBLE",
-        "lastModifiedBy": "shr.core.TimingCode"
+        "lastModifiedBy": "obf.datatype.TimingCode"
       }
     }
   }

--- a/test/fixtures/cimcore/shr-core/shr-core-Title.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Title.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Title",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Title",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Title",
   "isEntry": false,
   "isAbstract": false,
   "description": "A distinguishing word or group of words naming an item.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Type.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Type.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Type",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Type",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Type",
   "isEntry": false,
   "isAbstract": false,
   "description": "The most specific code (lowest level term) describing the kind or sort of thing being represented.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-UnitedStatesAddress.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-UnitedStatesAddress.json
@@ -1,20 +1,20 @@
 {
   "fileType": "DataElement",
   "name": "UnitedStatesAddress",
-  "namespace": "shr.core",
-  "fqn": "shr.core.UnitedStatesAddress",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.UnitedStatesAddress",
   "isEntry": false,
   "isAbstract": false,
   "description": "An address for a place in the USA, conforming to US mail postal conventions. (Source: HL7 FHIR).",
   "hierarchy": [
-    "shr.core.Address"
+    "obf.datatype.Address"
   ],
   "basedOn": [
-    "shr.core.Address"
+    "obf.datatype.Address"
   ],
   "fields": [
     {
-      "fqn": "shr.core.Purpose",
+      "fqn": "obf.datatype.Purpose",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -22,18 +22,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Coding": {
+          "obf.datatype.Coding": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/address-use",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Address"
+              "lastModifiedBy": "obf.datatype.Address"
             }
           }
         }
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       },
       "constraintHistory": {
         "valueSet": [
@@ -41,15 +41,15 @@
             "constraint": {
               "uri": "http://hl7.org/fhir/ValueSet/address-use",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Address"
+              "lastModifiedBy": "obf.datatype.Address"
             },
-            "source": "shr.core.UnitedStatesAddress"
+            "source": "obf.datatype.UnitedStatesAddress"
           }
         ]
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -57,18 +57,18 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/address-type",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Address"
+              "lastModifiedBy": "obf.datatype.Address"
             }
           }
         }
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       },
       "constraintHistory": {
         "valueSet": [
@@ -76,15 +76,15 @@
             "constraint": {
               "uri": "http://hl7.org/fhir/ValueSet/address-type",
               "bindingStrength": "REQUIRED",
-              "lastModifiedBy": "shr.core.Address"
+              "lastModifiedBy": "obf.datatype.Address"
             },
-            "source": "shr.core.UnitedStatesAddress"
+            "source": "obf.datatype.UnitedStatesAddress"
           }
         ]
       }
     },
     {
-      "fqn": "shr.core.DisplayText",
+      "fqn": "obf.datatype.DisplayText",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -92,11 +92,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       }
     },
     {
-      "fqn": "shr.core.AddressLine",
+      "fqn": "obf.datatype.AddressLine",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -104,11 +104,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       }
     },
     {
-      "fqn": "shr.core.City",
+      "fqn": "obf.datatype.City",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -116,11 +116,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       }
     },
     {
-      "fqn": "shr.core.District",
+      "fqn": "obf.datatype.District",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -128,23 +128,23 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       }
     },
     {
-      "fqn": "shr.core.State",
+      "fqn": "obf.datatype.State",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
         "max": 1,
         "history": [
           {
-            "source": "shr.core.Address",
+            "source": "obf.datatype.Address",
             "min": 0,
             "max": 1
           },
           {
-            "source": "shr.core.UnitedStatesAddress",
+            "source": "obf.datatype.UnitedStatesAddress",
             "min": 1,
             "max": 1
           }
@@ -152,24 +152,24 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.UnitedStatesState",
+          "fqn": "obf.datatype.UnitedStatesState",
           "onValue": false,
-          "lastModifiedBy": "shr.core.UnitedStatesAddress"
+          "lastModifiedBy": "obf.datatype.UnitedStatesAddress"
         }
       },
       "inheritance": {
         "status": "overridden",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       },
       "constraintHistory": {
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.UnitedStatesState",
+              "fqn": "obf.datatype.UnitedStatesState",
               "onValue": false,
-              "lastModifiedBy": "shr.core.UnitedStatesAddress"
+              "lastModifiedBy": "obf.datatype.UnitedStatesAddress"
             },
-            "source": "shr.core.UnitedStatesAddress"
+            "source": "obf.datatype.UnitedStatesAddress"
           }
         ],
         "card": [
@@ -177,15 +177,15 @@
             "constraint": {
               "min": 1,
               "max": 1,
-              "lastModifiedBy": "shr.core.UnitedStatesAddress"
+              "lastModifiedBy": "obf.datatype.UnitedStatesAddress"
             },
-            "source": "shr.core.UnitedStatesAddress"
+            "source": "obf.datatype.UnitedStatesAddress"
           }
         ]
       }
     },
     {
-      "fqn": "shr.core.PostalCode",
+      "fqn": "obf.datatype.PostalCode",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -193,11 +193,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       }
     },
     {
-      "fqn": "shr.core.Country",
+      "fqn": "obf.datatype.Country",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -205,11 +205,11 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -217,7 +217,7 @@
       },
       "inheritance": {
         "status": "inherited",
-        "from": "shr.core.Address"
+        "from": "obf.datatype.Address"
       }
     }
   ]

--- a/test/fixtures/cimcore/shr-core/shr-core-UnitedStatesState.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-UnitedStatesState.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "UnitedStatesState",
-  "namespace": "shr.core",
-  "fqn": "shr.core.UnitedStatesState",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.UnitedStatesState",
   "isEntry": false,
   "isAbstract": false,
   "description": "A state or territory in the USA expressed by 2-letter US Postal code.",
@@ -13,11 +13,11 @@
     }
   ],
   "hierarchy": [
-    "shr.core.GeopoliticalLocation",
-    "shr.core.State"
+    "obf.datatype.GeopoliticalLocation",
+    "obf.datatype.State"
   ],
   "basedOn": [
-    "shr.core.State"
+    "obf.datatype.State"
   ],
   "value": {
     "fqn": "string",
@@ -28,7 +28,7 @@
     },
     "inheritance": {
       "status": "inherited",
-      "from": "shr.core.State"
+      "from": "obf.datatype.State"
     }
   }
 }

--- a/test/fixtures/cimcore/shr-core/shr-core-Units.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Units.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Units",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Units",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Units",
   "isEntry": false,
   "isAbstract": false,
   "description": "Code for the unit of measure of the quantity.",
@@ -14,24 +14,24 @@
     },
     "options": [
       {
-        "fqn": "shr.core.Coding",
+        "fqn": "obf.datatype.Coding",
         "valueType": "IdentifiableValue",
         "constraints": {
           "valueSet": {
             "uri": "http://hl7.org/fhir/ValueSet/ucum-units",
             "bindingStrength": "REQUIRED",
-            "lastModifiedBy": "shr.core.Units"
+            "lastModifiedBy": "obf.datatype.Units"
           }
         }
       },
       {
-        "fqn": "shr.core.Coding",
+        "fqn": "obf.datatype.Coding",
         "valueType": "IdentifiableValue",
         "constraints": {
           "valueSet": {
-            "uri": "http://standardhealthrecord.org/shr/core/vs/CurrencyVS",
+            "uri": "http://standardhealthrecord.org/obf/datatype/vs/CurrencyVS",
             "bindingStrength": "REQUIRED",
-            "lastModifiedBy": "shr.core.Units"
+            "lastModifiedBy": "obf.datatype.Units"
           }
         }
       }

--- a/test/fixtures/cimcore/shr-core/shr-core-UpperBound.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-UpperBound.json
@@ -1,13 +1,13 @@
 {
   "fileType": "DataElement",
   "name": "UpperBound",
-  "namespace": "shr.core",
-  "fqn": "shr.core.UpperBound",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.UpperBound",
   "isEntry": false,
   "isAbstract": false,
   "description": "The upper limit on a quantitative value.",
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-core/shr-core-UpperLimit.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-UpperLimit.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "UpperLimit",
-  "namespace": "shr.core",
-  "fqn": "shr.core.UpperLimit",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.UpperLimit",
   "isEntry": false,
   "isAbstract": false,
   "description": "The upper limit of detection of the measured points. This is needed if any of the data points have the value 'U' (higher than detection limit).",

--- a/test/fixtures/cimcore/shr-core/shr-core-Version.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Version.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Version",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Version",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Version",
   "isEntry": false,
   "isAbstract": false,
   "description": "A number or code associated with the product that identifies a particular release iteration.",

--- a/test/fixtures/cimcore/shr-core/shr-core-Volume.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Volume.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Volume",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Volume",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Volume",
   "isEntry": false,
   "isAbstract": false,
   "description": "The amount of three dimensional space occupied by an object or the capacity of a space or container.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,16 +21,16 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {
                   "system": "http://unitsofmeasure.org",
                   "code": "TBD"
                 },
-                "lastModifiedBy": "shr.core.Volume"
+                "lastModifiedBy": "obf.datatype.Volume"
               }
             }
           }

--- a/test/fixtures/cimcore/shr-core/shr-core-Width.json
+++ b/test/fixtures/cimcore/shr-core/shr-core-Width.json
@@ -1,8 +1,8 @@
 {
   "fileType": "DataElement",
   "name": "Width",
-  "namespace": "shr.core",
-  "fqn": "shr.core.Width",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.Width",
   "isEntry": false,
   "isAbstract": false,
   "description": "The measurement or extent of something from side to side.",
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,16 +21,16 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {
                   "system": "http://unitsofmeasure.org",
                   "code": "TBD"
                 },
-                "lastModifiedBy": "shr.core.Width"
+                "lastModifiedBy": "obf.datatype.Width"
               }
             }
           }

--- a/test/fixtures/cimcore/shr-core/shr-core.json
+++ b/test/fixtures/cimcore/shr-core/shr-core.json
@@ -1,5 +1,5 @@
 {
   "fileType": "Namespace",
-  "name": "shr.core",
+  "name": "obf.datatype",
   "description": "The SHR Core domain contains definitions for a variety of general-purpose elements that are used widely in SHR. These include definitions for coding, expressions of time, quantities, addresses, names, and more."
 }

--- a/test/fixtures/cimcore/shr-core/valuesets/AgeGroupVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/AgeGroupVS.json
@@ -1,9 +1,9 @@
 {
   "fileType": "ValueSet",
   "name": "AgeGroupVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.AgeGroupVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#AgeGroupVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.AgeGroupVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#AgeGroupVS",
   "values": [
     {
       "system": "http://ncimeta.nci.nih.gov",

--- a/test/fixtures/cimcore/shr-core/valuesets/BodyPositionVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/BodyPositionVS.json
@@ -1,8 +1,8 @@
 {
   "fileType": "ValueSet",
   "name": "BodyPositionVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.BodyPositionVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.BodyPositionVS",
   "description": "The body position with respect to gravity.",
   "concepts": [
     {
@@ -10,7 +10,7 @@
       "code": "8361-8"
     }
   ],
-  "url": "http://standardhealthrecord.org/shr/core/vs/#BodyPositionVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#BodyPositionVS",
   "values": [
     {
       "system": "http://ncimeta.nci.nih.gov",

--- a/test/fixtures/cimcore/shr-core/valuesets/ClinicalFindingAbsentVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/ClinicalFindingAbsentVS.json
@@ -1,9 +1,9 @@
 {
   "fileType": "ValueSet",
   "name": "ClinicalFindingAbsentVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ClinicalFindingAbsentVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#ClinicalFindingAbsentVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ClinicalFindingAbsentVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#ClinicalFindingAbsentVS",
   "rules": {
     "includesDescendants": [
       {

--- a/test/fixtures/cimcore/shr-core/valuesets/ClockDirectionVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/ClockDirectionVS.json
@@ -1,10 +1,10 @@
 {
   "fileType": "ValueSet",
   "name": "ClockDirectionVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ClockDirectionVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ClockDirectionVS",
   "description": "The relative direction of an object described using the analogy of a 12-hour clock to describe angles and directions. One imagines a clock face lying either upright or flat in front of oneself, and identifies the twelve hour markings with the directions in which they point.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#ClockDirectionVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#ClockDirectionVS",
   "rules": {
     "includesDescendants": [
       {

--- a/test/fixtures/cimcore/shr-core/valuesets/CodingQualifierVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/CodingQualifierVS.json
@@ -1,42 +1,42 @@
 {
   "fileType": "ValueSet",
   "name": "CodingQualifierVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.CodingQualifierVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#CodingQualifierVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.CodingQualifierVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#CodingQualifierVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#CodingQualifierCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#CodingQualifierCS",
       "code": "preferred_code",
       "description": "The preferred, standardized code for interoperability purposes. There should be only one coding in a CodeableConcept with this tag."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#CodingQualifierCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#CodingQualifierCS",
       "code": "source_code",
       "description": "The code found in the information source for this entry, e.g., the raw, original, or first encoding."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#CodingQualifierCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#CodingQualifierCS",
       "code": "user_selected_code",
       "description": "The code was directly selected by the user, as opposed to being determined after the fact via interpretation of notes or natural language processing."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#CodingQualifierCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#CodingQualifierCS",
       "code": "derived_code",
       "description": "The code was determined after-the-fact from source data, either through translation, or via interpretation of free text (by human or machine)."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#CodingQualifierCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#CodingQualifierCS",
       "code": "category_code",
       "description": "Indicates the code is a less specific term or a categorization of the source or standard code, i.e., a hypernym. For example, a code for 'vital sign' in the context of a body weight measurement would be a category code. Category codes can  be useful for search and query purposes."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#CodingQualifierCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#CodingQualifierCS",
       "code": "coded_expression",
       "description": "The code is an expression in an expression language defined by the CodeSystem"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#CodingQualifierCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#CodingQualifierCS",
       "code": "default_code",
       "description": "The code was supplied by the system by default, because no specific coded value was available."
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/ConditionCategoryVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/ConditionCategoryVS.json
@@ -1,37 +1,37 @@
 {
   "fileType": "ValueSet",
   "name": "ConditionCategoryVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ConditionCategoryVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#ConditionCategoryVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ConditionCategoryVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#ConditionCategoryVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#ConditionCategoryCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#ConditionCategoryCS",
       "code": "disease",
       "description": "A disorder of structure or function in a human, animal, or plant, especially one that produces specific signs or symptoms or that affects a specific location and is not simply a direct result of physical injury."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#ConditionCategoryCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#ConditionCategoryCS",
       "code": "functional_impairment",
       "description": "A disability experienced by the subject."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#ConditionCategoryCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#ConditionCategoryCS",
       "code": "structural_abnormality",
       "description": "An abnormality of physiologic structure."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#ConditionCategoryCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#ConditionCategoryCS",
       "code": "concern",
       "description": "Something the subject is worried about, which may or may not have yet been manifested. The object of the concern does not have to be a medical disorder."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#ConditionCategoryCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#ConditionCategoryCS",
       "code": "symptom",
       "description": "A sign or manifestation of a deeper cause, of known or unknown etiology, e.g. pain or ringing in the ears."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#ConditionCategoryCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#ConditionCategoryCS",
       "code": "adverse_reaction",
       "description": "An adverse reaction to an intervention."
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/CurrencyVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/CurrencyVS.json
@@ -1,10 +1,10 @@
 {
   "fileType": "ValueSet",
   "name": "CurrencyVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.CurrencyVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.CurrencyVS",
   "description": "Value set containing ISO 4217 currency codes.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#CurrencyVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#CurrencyVS",
   "rules": {
     "includesFromCodeSystem": [
       {

--- a/test/fixtures/cimcore/shr-core/valuesets/DiseaseFindingVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/DiseaseFindingVS.json
@@ -1,9 +1,9 @@
 {
   "fileType": "ValueSet",
   "name": "DiseaseFindingVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.DiseaseFindingVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#DiseaseFindingVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.DiseaseFindingVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#DiseaseFindingVS",
   "rules": {
     "includesDescendants": [
       {

--- a/test/fixtures/cimcore/shr-core/valuesets/LowerBoundTypeVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/LowerBoundTypeVS.json
@@ -1,10 +1,10 @@
 {
   "fileType": "ValueSet",
   "name": "LowerBoundTypeVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.LowerBoundTypeVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.LowerBoundTypeVS",
   "description": "Indicates the actual value is gt (>) or gte (>=) the given value.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#LowerBoundTypeVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#LowerBoundTypeVS",
   "values": [
     {
       "system": "http://hl7.org/fhir/quantity-comparator",

--- a/test/fixtures/cimcore/shr-core/valuesets/PerformanceGradingScaleVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/PerformanceGradingScaleVS.json
@@ -1,33 +1,33 @@
 {
   "fileType": "ValueSet",
   "name": "PerformanceGradingScaleVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.PerformanceGradingScaleVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.PerformanceGradingScaleVS",
   "description": "A simple performance grading scale. Also useful for grading quality.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#PerformanceGradingScaleVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#PerformanceGradingScaleVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#PerformanceGradingScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#PerformanceGradingScaleCS",
       "code": "excellent",
       "description": "Excellent"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#PerformanceGradingScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#PerformanceGradingScaleCS",
       "code": "very_good",
       "description": "Very good"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#PerformanceGradingScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#PerformanceGradingScaleCS",
       "code": "good",
       "description": "Good"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#PerformanceGradingScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#PerformanceGradingScaleCS",
       "code": "fair",
       "description": "Fair"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#PerformanceGradingScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#PerformanceGradingScaleCS",
       "code": "poor",
       "description": "Poor"
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/QualitativeDateTimeVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/QualitativeDateTimeVS.json
@@ -1,107 +1,107 @@
 {
   "fileType": "ValueSet",
   "name": "QualitativeDateTimeVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.QualitativeDateTimeVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#QualitativeDateTimeVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.QualitativeDateTimeVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#QualitativeDateTimeVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "past",
       "description": "A time or time period in the indefinite past"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "many_years_ago",
       "description": "Many years ago"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "several_years_ago",
       "description": "Several years ago"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "one_year_ago",
       "description": "About a year ago"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "months_ago",
       "description": "Several months ago"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "weeks_ago",
       "description": "Several weeks ago"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "days_ago",
       "description": "Several days ago"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "hours_ago",
       "description": "Several hours ago"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "minutes_ago",
       "description": "Several minutes ago"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "preexisting",
       "description": "At a time previous to the current encounter or admission"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "now",
       "description": "Now, currently, presently continuing or ongoing"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "minutes_hence",
       "description": "Several minutes from now"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "hours_hence",
       "description": "Several hours from now"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "days_hence",
       "description": "Several days from now"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "weeks_hence",
       "description": "Several weeks from now"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "months_hence",
       "description": "Several months from now"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "one_year_hence",
       "description": "About a year from now"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "several_years_hence",
       "description": "Several years from now"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "many_years_hence",
       "description": "Many years from now"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeDateTimeCS",
       "code": "future",
       "description": "A time or time period in the indefinite future"
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/QualitativeFrequencyVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/QualitativeFrequencyVS.json
@@ -1,33 +1,33 @@
 {
   "fileType": "ValueSet",
   "name": "QualitativeFrequencyVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.QualitativeFrequencyVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.QualitativeFrequencyVS",
   "description": "Code set indicating the frequency of an event in qualitative terms.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#QualitativeFrequencyVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#QualitativeFrequencyVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeFrequencyCS",
       "code": "always",
       "description": "Virtually always or every time"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeFrequencyCS",
       "code": "usually",
       "description": "Frequently or often"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeFrequencyCS",
       "code": "sometimes",
       "description": "Occasionally or sometimes"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeFrequencyCS",
       "code": "rarely",
       "description": "Rarely"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeFrequencyCS",
       "code": "never",
       "description": "Never"
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/QualitativeLikelihoodVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/QualitativeLikelihoodVS.json
@@ -1,38 +1,38 @@
 {
   "fileType": "ValueSet",
   "name": "QualitativeLikelihoodVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.QualitativeLikelihoodVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.QualitativeLikelihoodVS",
   "description": "The likelihood of an event or state, expressed qualitatively. Qualitative likelihoods are associated with judgments and assessments. Values are based on US Intelligence Community's standard language used to describe judgements of likelihood.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#QualitativeLikelihoodVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#QualitativeLikelihoodVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeLikelihoodCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeLikelihoodCS",
       "code": "definitely",
       "description": "With certainty or near-complete certainty, an event that definitely has or almost certainly will happen"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeLikelihoodCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeLikelihoodCS",
       "code": "very_likely",
       "description": "Very likely, highly probable, e.g., an event with more than 80% but less than 100% likelihood"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeLikelihoodCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeLikelihoodCS",
       "code": "likely",
       "description": "Likely or probable, e.g., an event with 60% to 80% likelihood"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeLikelihoodCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeLikelihoodCS",
       "code": "even_chance",
       "description": "Roughly equal chance or even odds of happening, between 40% and 60% probability"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeLikelihoodCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeLikelihoodCS",
       "code": "unlikely",
       "description": "Not likely or improbable, e.g., an event with 20% to 40% likelihood"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeLikelihoodCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeLikelihoodCS",
       "code": "very_unlikely",
       "description": "Very unlikely, highly improbable, e.g., an event with less than 20% but non-zero likelihood"
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/QualitativeValueScaleVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/QualitativeValueScaleVS.json
@@ -1,32 +1,32 @@
 {
   "fileType": "ValueSet",
   "name": "QualitativeValueScaleVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.QualitativeValueScaleVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#QualitativeValueScaleVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.QualitativeValueScaleVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#QualitativeValueScaleVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeValueScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeValueScaleCS",
       "code": "very_high",
       "description": "Very high"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeValueScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeValueScaleCS",
       "code": "high",
       "description": "High"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeValueScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeValueScaleCS",
       "code": "moderate",
       "description": "Moderate/Intermediate or Borderline"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeValueScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeValueScaleCS",
       "code": "low",
       "description": "Low"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#QualitativeValueScaleCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#QualitativeValueScaleCS",
       "code": "very_low",
       "description": "Very low"
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/SemiquantitativeDurationVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/SemiquantitativeDurationVS.json
@@ -1,52 +1,52 @@
 {
   "fileType": "ValueSet",
   "name": "SemiquantitativeDurationVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.SemiquantitativeDurationVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#SemiquantitativeDurationVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.SemiquantitativeDurationVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#SemiquantitativeDurationVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeDurationCS",
       "code": "many_years",
       "description": "Many years"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeDurationCS",
       "code": "several_years",
       "description": "Several years"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeDurationCS",
       "code": "one_year",
       "description": "About a year"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeDurationCS",
       "code": "months",
       "description": "Several months but less than a year"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeDurationCS",
       "code": "weeks",
       "description": "Several weeks but less than a month"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeDurationCS",
       "code": "days",
       "description": "Several days but less than a week"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeDurationCS",
       "code": "hours",
       "description": "Several hours but less than a day"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeDurationCS",
       "code": "minutes",
       "description": "Several minutes but less than an hour"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeDurationCS",
       "code": "seconds",
       "description": "Several seconds but less than a minute"
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/SemiquantitativeFrequencyVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/SemiquantitativeFrequencyVS.json
@@ -1,72 +1,72 @@
 {
   "fileType": "ValueSet",
   "name": "SemiquantitativeFrequencyVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.SemiquantitativeFrequencyVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#SemiquantitativeFrequencyVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.SemiquantitativeFrequencyVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#SemiquantitativeFrequencyVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "never",
       "description": "Never"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "less_than_yearly",
       "description": "Less than yearly"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "yearly",
       "description": "Yearly"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "mot_yearly",
       "description": "More than once yearly"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "monthly",
       "description": "Monthly"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "weekly",
       "description": "Weekly"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "mto_weekly",
       "description": "More than once weekly"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "daily",
       "description": "Daily"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "mto_daily",
       "description": "More than once daily"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "hourly",
       "description": "Hourly"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "mto_hourly",
       "description": "More than once hourly"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "minutely",
       "description": "Every minute"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SemiquantitativeFrequencyCS",
       "code": "continuously",
       "description": "Continuously"
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/SettingVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/SettingVS.json
@@ -1,178 +1,178 @@
 {
   "fileType": "ValueSet",
   "name": "SettingVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.SettingVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.SettingVS",
   "description": "What type of place is found at a given location. More than one descriptor may be applicable.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#SettingVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#SettingVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "work",
       "description": "At or during work, in a workplace setting."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "home",
       "description": "At home"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "residental",
       "description": "In a residential setting"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "school",
       "description": "A primary or secondary school"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "vehicle",
       "description": "In a parked or moving vehicle"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "office",
       "description": "An non-manufacturing, indoor business setting"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "factory",
       "description": "A manufacturing-oriented business setting"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "business",
       "description": "A place of business"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "restaurant",
       "description": "A setting where food is served"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "food_prep",
       "description": "A place where food is prepared"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "worksite",
       "description": "Workplace that is primarily outdoors"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "manufacturing",
       "description": "A setting where manufacturing takes place"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "owned",
       "description": "A building or residence that is owned"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "rental",
       "description": "A building or residence that is rented"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "dorm",
       "description": "Shared (unassisted) living residence, such as a dormitory or fraternity"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "foster",
       "description": "Foster care group home"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "assisted",
       "description": "Assisted living or independent living facility"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "snf",
       "description": "Skilled nursing facility or other Long-Term Care"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "shelter",
       "description": "Homeless or other type of shelter"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "hotel",
       "description": "Hotel or motel"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "psh",
       "description": "Permanent supportive housing for formerly homeless persons (such as SHP, S+C, or SRO Mod Rehab)"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "psych",
       "description": "Psychiatric hospital or other psychiatric facility"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "detox",
       "description": "Substance abuse treatment facility or detox center"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "prison",
       "description": "Individual resides in a correctional facility, state hospital, jail, prison, youth authority facility, juvenile hall, boot camp or Boys Ranch."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "transition",
       "description": "Transitional housing, residential provier program, or any type of halfway house"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "squat",
       "description": "A homeless camp, abandoned building, shantytown, bus/train/subway station/airport, or squatter area"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "outdoors",
       "description": "Outside of any shelter, e.g., on a street"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "agricultural",
       "description": "Agricultural setting"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "farm",
       "description": "A farm with livestock"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "battlefield",
       "description": "On a battlefield"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "deployed",
       "description": "Deployed to a military camp or area"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "ship",
       "description": "On a boat"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "airplane",
       "description": "On an airplane"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#SettingCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#SettingCS",
       "code": "submarine",
       "description": "Aboard a submarine"
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/StatisticTypeVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/StatisticTypeVS.json
@@ -1,10 +1,10 @@
 {
   "fileType": "ValueSet",
   "name": "StatisticTypeVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.StatisticTypeVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.StatisticTypeVS",
   "description": "How to interpret a reported quantity, i.e, whether the quantity is an maximum, minimum, mean, median, etc.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#StatisticTypeVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#StatisticTypeVS",
   "values": [
     {
       "system": "http://ncimeta.nci.nih.gov",

--- a/test/fixtures/cimcore/shr-core/valuesets/ThreePriorityVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/ThreePriorityVS.json
@@ -1,22 +1,22 @@
 {
   "fileType": "ValueSet",
   "name": "ThreePriorityVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.ThreePriorityVS",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#ThreePriorityVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.ThreePriorityVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#ThreePriorityVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#ThreePriorityCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#ThreePriorityCS",
       "code": "primary",
       "description": "The first or primary item or alterative in a preference list."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#ThreePriorityCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#ThreePriorityCS",
       "code": "secondary",
       "description": "The second or backup preference."
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#ThreePriorityCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#ThreePriorityCS",
       "code": "third_or_lower",
       "description": "An alternative to primary and secondard choices in a preference list."
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/TimeUnitOfMeasureVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/TimeUnitOfMeasureVS.json
@@ -1,10 +1,10 @@
 {
   "fileType": "ValueSet",
   "name": "TimeUnitOfMeasureVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.TimeUnitOfMeasureVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.TimeUnitOfMeasureVS",
   "description": "Units of measure related to time.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#TimeUnitOfMeasureVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#TimeUnitOfMeasureVS",
   "values": [
     {
       "system": "http://unitsofmeasure.org",

--- a/test/fixtures/cimcore/shr-core/valuesets/UnitsOfLengthVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/UnitsOfLengthVS.json
@@ -1,10 +1,10 @@
 {
   "fileType": "ValueSet",
   "name": "UnitsOfLengthVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.UnitsOfLengthVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.UnitsOfLengthVS",
   "description": "Units of measure related to length or distance.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#UnitsOfLengthVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#UnitsOfLengthVS",
   "values": [
     {
       "system": "http://unitsofmeasure.org",

--- a/test/fixtures/cimcore/shr-core/valuesets/UpperBoundTypeVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/UpperBoundTypeVS.json
@@ -1,10 +1,10 @@
 {
   "fileType": "ValueSet",
   "name": "UpperBoundTypeVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.UpperBoundTypeVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.UpperBoundTypeVS",
   "description": "Indicates the actual value is lt (<) or lte (<=) the given value.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#UpperBoundTypeVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#UpperBoundTypeVS",
   "values": [
     {
       "system": "http://hl7.org/fhir/quantity-comparator",

--- a/test/fixtures/cimcore/shr-core/valuesets/YesNoUnknownVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/YesNoUnknownVS.json
@@ -1,23 +1,23 @@
 {
   "fileType": "ValueSet",
   "name": "YesNoUnknownVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.YesNoUnknownVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.YesNoUnknownVS",
   "description": "Code set indicating yes, no, or unknown.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#YesNoUnknownVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#YesNoUnknownVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#YesNoUnknownCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#YesNoUnknownCS",
       "code": "yes",
       "description": "Yes, or true"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#YesNoUnknownCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#YesNoUnknownCS",
       "code": "no",
       "description": "No, or false"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#YesNoUnknownCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#YesNoUnknownCS",
       "code": "unknown",
       "description": "Unknown"
     }

--- a/test/fixtures/cimcore/shr-core/valuesets/YesNoVS.json
+++ b/test/fixtures/cimcore/shr-core/valuesets/YesNoVS.json
@@ -1,18 +1,18 @@
 {
   "fileType": "ValueSet",
   "name": "YesNoVS",
-  "namespace": "shr.core",
-  "fqn": "shr.core.YesNoVS",
+  "namespace": "obf.datatype",
+  "fqn": "obf.datatype.YesNoVS",
   "description": "Code set indicating yes or no.",
-  "url": "http://standardhealthrecord.org/shr/core/vs/#YesNoVS",
+  "url": "http://standardhealthrecord.org/obf/datatype/vs/#YesNoVS",
   "values": [
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#YesNoCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#YesNoCS",
       "code": "yes",
       "description": "Yes, or true"
     },
     {
-      "system": "http://standardhealthrecord.org/shr/core/cs/#YesNoCS",
+      "system": "http://standardhealthrecord.org/obf/datatype/cs/#YesNoCS",
       "code": "no",
       "description": "No, or false"
     }

--- a/test/fixtures/cimcore/shr-financial/mappings/Coverage-mapping.json
+++ b/test/fixtures/cimcore/shr-financial/mappings/Coverage-mapping.json
@@ -16,7 +16,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "shr.financial.Coverage"
@@ -30,7 +30,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
         "lastModifiedBy": "shr.financial.Coverage"

--- a/test/fixtures/cimcore/shr-financial/shr-financial-Coverage.json
+++ b/test/fixtures/cimcore/shr-financial/shr-financial-Coverage.json
@@ -148,7 +148,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -156,7 +156,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/coverage-type",
               "bindingStrength": "PREFERRED",
@@ -195,7 +195,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-occupation/mappings/MilitaryServiceHistory-mapping.json
+++ b/test/fixtures/cimcore/shr-occupation/mappings/MilitaryServiceHistory-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-occupation/mappings/OccupationalDataSummaryPanel-mapping.json
+++ b/test/fixtures/cimcore/shr-occupation/mappings/OccupationalDataSummaryPanel-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.PanelTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-occupation/mappings/PastOrPresentJob-mapping.json
+++ b/test/fixtures/cimcore/shr-occupation/mappings/PastOrPresentJob-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-occupation/mappings/UsualOccupation-mapping.json
+++ b/test/fixtures/cimcore/shr-occupation/mappings/UsualOccupation-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-CombatZoneHazardousDutyPeriod.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-CombatZoneHazardousDutyPeriod.json
@@ -19,7 +19,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.TimePeriod",
+    "fqn": "obf.datatype.TimePeriod",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-CurrentEmploymentStatus.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-CurrentEmploymentStatus.json
@@ -21,7 +21,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -57,7 +57,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -70,7 +70,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-Industry.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-Industry.json
@@ -14,7 +14,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -50,7 +50,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -63,7 +63,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-JobClassification.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-JobClassification.json
@@ -20,7 +20,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -56,7 +56,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -69,7 +69,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryBranch.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryBranch.json
@@ -20,7 +20,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -56,7 +56,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -69,7 +69,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryServiceDischargeStatus.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryServiceDischargeStatus.json
@@ -14,7 +14,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -50,7 +50,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -63,7 +63,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryServiceEra.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryServiceEra.json
@@ -14,7 +14,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -50,7 +50,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -63,7 +63,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryServiceHistory.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryServiceHistory.json
@@ -148,9 +148,9 @@
               "lastModifiedBy": "cimi.statement.NonLabCodedEvaluationResultRecorded"
             }
           },
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -164,7 +164,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -366,7 +366,7 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "cimi.statement.CodedEvaluationResultRecorded"
             }
@@ -388,7 +388,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.statement.CodedEvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryStatus.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-MilitaryStatus.json
@@ -20,7 +20,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -56,7 +56,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -69,7 +69,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-Occupation.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-Occupation.json
@@ -20,7 +20,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -56,7 +56,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -69,7 +69,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-OccupationalDataSummaryPanel.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-OccupationalDataSummaryPanel.json
@@ -155,7 +155,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -167,9 +167,9 @@
               }
             }
           },
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-PastOrPresentJob.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-PastOrPresentJob.json
@@ -154,9 +154,9 @@
               "lastModifiedBy": "cimi.statement.NonLabCodedEvaluationResultRecorded"
             }
           },
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -429,7 +429,7 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "cimi.statement.CodedEvaluationResultRecorded"
             },
@@ -463,7 +463,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.statement.CodedEvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-ServiceConnectedDisability.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-ServiceConnectedDisability.json
@@ -13,7 +13,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,9 +21,9 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-SupervisoryLevel.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-SupervisoryLevel.json
@@ -14,7 +14,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -50,7 +50,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -63,7 +63,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-TotalDuration.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-TotalDuration.json
@@ -13,7 +13,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,9 +21,9 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "valueSet": {
                 "uri": "http://hl7.org/fhir/ValueSet/units-of-time",
                 "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-UsualOccupation.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-UsualOccupation.json
@@ -154,9 +154,9 @@
               "lastModifiedBy": "cimi.statement.NonLabCodedEvaluationResultRecorded"
             }
           },
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -286,12 +286,12 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "cimi.statement.CodedEvaluationResultRecorded"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://hl7.org/fhir/ValueSet/occupation-cdc-census-2010",
                   "bindingStrength": "EXAMPLE",
@@ -327,7 +327,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.statement.CodedEvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-WorkDaysPerWeek.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-WorkDaysPerWeek.json
@@ -13,7 +13,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,9 +21,9 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-WorkHoursPerDay.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-WorkHoursPerDay.json
@@ -13,7 +13,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -21,9 +21,9 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {

--- a/test/fixtures/cimcore/shr-occupation/shr-occupation-WorkSchedule.json
+++ b/test/fixtures/cimcore/shr-occupation/shr-occupation-WorkSchedule.json
@@ -19,7 +19,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-oncology/mappings/BreastCancerHistologicGrade-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/BreastCancerHistologicGrade-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/BreastCancerPresenceStatement-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/BreastCancerPresenceStatement-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "_Entry",
-          "shr.core.CreationTime"
+          "obf.datatype.CreationTime"
         ],
         "target": "assertedDate",
         "lastModifiedBy": "cimi.statement.ConditionPresenceStatement"
@@ -37,7 +37,7 @@
       {
         "sourcePath": [
           "cimi.topic.ConditionTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.ConditionPresenceStatement"
@@ -118,7 +118,7 @@
         "sourcePath": [
           "cimi.context.ConditionPresenceContext",
           "cimi.context.Stage",
-          "shr.core.CodeableConcept"
+          "obf.datatype.CodeableConcept"
         ],
         "target": "stage.summary",
         "lastModifiedBy": "cimi.statement.ConditionPresenceStatement"

--- a/test/fixtures/cimcore/shr-oncology/mappings/BreastCancerStage-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/BreastCancerStage-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.PanelTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/BreastSite-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/BreastSite-mapping.json
@@ -13,7 +13,7 @@
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.CodeableConcept"
+          "obf.datatype.CodeableConcept"
         ],
         "target": "code",
         "lastModifiedBy": "cimi.element.AnatomicalLocation"

--- a/test/fixtures/cimcore/shr-oncology/mappings/BreastSpecimen-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/BreastSpecimen-mapping.json
@@ -27,7 +27,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "type",
         "lastModifiedBy": "cimi.entity.Specimen"
@@ -48,7 +48,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.ReceivedTime"
+          "obf.datatype.ReceivedTime"
         ],
         "target": "receivedTime",
         "lastModifiedBy": "cimi.entity.Specimen"
@@ -64,7 +64,7 @@
       {
         "sourcePath": [
           "cimi.entity.SpecimenContainer",
-          "shr.core.Details"
+          "obf.datatype.Details"
         ],
         "target": "container.description",
         "lastModifiedBy": "cimi.entity.Specimen"
@@ -72,7 +72,7 @@
       {
         "sourcePath": [
           "cimi.entity.SpecimenContainer",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "container.type",
         "lastModifiedBy": "cimi.entity.Specimen"
@@ -111,7 +111,7 @@
       {
         "sourcePath": [
           "shr.oncology.ColdIschemiaTime",
-          "shr.core.TimePeriod"
+          "obf.datatype.TimePeriod"
         ],
         "target": "processing.time[x]",
         "lastModifiedBy": "shr.oncology.BreastSpecimen"

--- a/test/fixtures/cimcore/shr-oncology/mappings/DCISNuclearGrade-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/DCISNuclearGrade-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/EstrogenReceptorStatus-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/EstrogenReceptorStatus-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/HER2ReceptorStatus-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/HER2ReceptorStatus-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.PanelTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.PanelTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/HER2byIHC-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/HER2byIHC-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/HER2byISH-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/HER2byISH-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/MammaprintRecurrenceScore-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/MammaprintRecurrenceScore-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/OncotypeDxDCISRecurrenceScore-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/OncotypeDxDCISRecurrenceScore-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/OncotypeDxInvasiveRecurrenceScore-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/OncotypeDxInvasiveRecurrenceScore-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/ProgesteroneReceptorStatus-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/ProgesteroneReceptorStatus-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/mappings/ProsignaRecurrenceScore-mapping.json
+++ b/test/fixtures/cimcore/shr-oncology/mappings/ProsignaRecurrenceScore-mapping.json
@@ -14,7 +14,7 @@
       {
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
-          "shr.core.Category"
+          "obf.datatype.Category"
         ],
         "target": "category",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -103,8 +103,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.LowerBound"
+          "obf.datatype.Range",
+          "obf.datatype.LowerBound"
         ],
         "target": "referenceRange.low",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -113,8 +113,8 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Range",
-          "shr.core.UpperBound"
+          "obf.datatype.Range",
+          "obf.datatype.UpperBound"
         ],
         "target": "referenceRange.high",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
@@ -123,7 +123,7 @@
         "sourcePath": [
           "cimi.topic.EvaluationResultTopic",
           "cimi.topic.ReferenceRange",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "referenceRange.type",
         "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-AverageCEP17SignalsPerCell.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-AverageCEP17SignalsPerCell.json
@@ -19,7 +19,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-AverageHER2SignalsPerCell.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-AverageHER2SignalsPerCell.json
@@ -19,7 +19,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-AverageStainingIntensity.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-AverageStainingIntensity.json
@@ -21,7 +21,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -57,7 +57,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -70,7 +70,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerDistantMetastasesClassification.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerDistantMetastasesClassification.json
@@ -21,7 +21,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -38,7 +38,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -51,7 +51,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerHistologicGrade.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerHistologicGrade.json
@@ -133,9 +133,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -170,7 +170,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -346,12 +346,12 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.BreastCancerHistologicGrade"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/NottinghamCombinedGradeVS",
                   "bindingStrength": "REQUIRED",
@@ -362,7 +362,7 @@
           },
           "cimi.context.ExceptionValue": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/NottinghamNullVS",
                   "bindingStrength": "REQUIRED",
@@ -406,7 +406,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.BreastCancerHistologicGrade"
             },
@@ -423,7 +423,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerPresenceStatement.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerPresenceStatement.json
@@ -178,7 +178,7 @@
         "subpaths": {
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/BreastCancerTypeVS",
                   "bindingStrength": "REQUIRED",
@@ -189,7 +189,7 @@
           },
           "cimi.topic.FindingMethod": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/BreastCancerDetectionVS",
                   "bindingStrength": "PREFERRED",
@@ -313,7 +313,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/shr/oncology/vs/MorphologyBehaviorVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerPrimaryTumorClassification.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerPrimaryTumorClassification.json
@@ -21,7 +21,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -38,7 +38,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -51,7 +51,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerRegionalNodesClassification.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerRegionalNodesClassification.json
@@ -21,7 +21,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -38,7 +38,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -51,7 +51,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerStage.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastCancerStage.json
@@ -129,9 +129,9 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -145,7 +145,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -457,12 +457,12 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.BreastCancerStage"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/BreastCancerStageVS",
                   "bindingStrength": "EXAMPLE",
@@ -498,7 +498,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.BreastCancerStage"
             },

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastSite.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastSite.json
@@ -13,7 +13,7 @@
     "cimi.element.AnatomicalLocation"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -93,7 +93,7 @@
       }
     },
     {
-      "fqn": "shr.core.ClockDirection",
+      "fqn": "obf.datatype.ClockDirection",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastSpecimen.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-BreastSpecimen.json
@@ -38,7 +38,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://hl7.org/fhir/ValueSet/specimen-status",
               "bindingStrength": "REQUIRED",
@@ -64,7 +64,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -72,7 +72,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/shr/oncology/vs/BreastSpecimenTypeVS",
               "bindingStrength": "REQUIRED",
@@ -175,7 +175,7 @@
       }
     },
     {
-      "fqn": "shr.core.ReceivedTime",
+      "fqn": "obf.datatype.ReceivedTime",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -207,7 +207,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/shr/oncology/vs/BreastSpecimenCollectionMethodVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-ColdIschemiaTime.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-ColdIschemiaTime.json
@@ -13,7 +13,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.TimePeriod",
+    "fqn": "obf.datatype.TimePeriod",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-CompleteMembraneStainingPercent.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-CompleteMembraneStainingPercent.json
@@ -20,7 +20,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -28,9 +28,9 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-DCISNuclearGrade.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-DCISNuclearGrade.json
@@ -133,9 +133,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -177,7 +177,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -292,12 +292,12 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.DCISNuclearGrade"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/NuclearGradeVS",
                   "bindingStrength": "REQUIRED",
@@ -333,7 +333,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.DCISNuclearGrade"
             },

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-DistanceFromBreastSiteToNipple.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-DistanceFromBreastSiteToNipple.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "Distance between the feature of interest (e.g., the tumor) and the nipple.",
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -15,9 +15,9 @@
     },
     "constraints": {
       "subpaths": {
-        "shr.core.Units": {
+        "obf.datatype.Units": {
           "subpaths": {
-            "shr.core.Coding": {
+            "obf.datatype.Coding": {
               "fixedValue": {
                 "type": "code",
                 "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-EstrogenReceptorStatus.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-EstrogenReceptorStatus.json
@@ -134,9 +134,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -171,7 +171,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -326,12 +326,12 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.EstrogenReceptorStatus"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/PositiveNegativeVS",
                   "bindingStrength": "REQUIRED",
@@ -367,7 +367,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.EstrogenReceptorStatus"
             },
@@ -384,7 +384,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-HER2ReceptorStatus.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-HER2ReceptorStatus.json
@@ -129,9 +129,9 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -145,7 +145,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -368,12 +368,12 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.HER2ReceptorStatus"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/PositiveNegativeEquivocalVS",
                   "bindingStrength": "REQUIRED",
@@ -409,7 +409,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.HER2ReceptorStatus"
             },
@@ -426,7 +426,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-HER2byIHC.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-HER2byIHC.json
@@ -132,9 +132,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -148,7 +148,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -308,12 +308,12 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.HER2byIHC"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/HER2byIHCScoreVS",
                   "bindingStrength": "REQUIRED",
@@ -324,7 +324,7 @@
           },
           "cimi.context.Interpretation": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/PositiveNegativeEquivocalVS",
                   "bindingStrength": "REQUIRED",
@@ -368,7 +368,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.HER2byIHC"
             },
@@ -385,7 +385,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-HER2byISH.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-HER2byISH.json
@@ -132,9 +132,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -148,7 +148,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -163,7 +163,7 @@
           },
           "cimi.topic.FindingMethod": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/HER2ISHMethodVS",
                   "bindingStrength": "REQUIRED",
@@ -363,7 +363,7 @@
           },
           "cimi.context.Interpretation": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/PositiveNegativeEquivocalVS",
                   "bindingStrength": "REQUIRED",
@@ -418,7 +418,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-HER2toCEP17Ratio.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-HER2toCEP17Ratio.json
@@ -19,7 +19,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.Quantity",
+    "fqn": "obf.datatype.Quantity",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-MammaprintRecurrenceScore.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-MammaprintRecurrenceScore.json
@@ -133,9 +133,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -170,7 +170,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -292,14 +292,14 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.Quantity",
+              "fqn": "obf.datatype.Quantity",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.MammaprintRecurrenceScore"
             }
           },
           "cimi.context.Interpretation": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/MammaprintRiskScoreInterpretationVS",
                   "bindingStrength": "REQUIRED",
@@ -335,7 +335,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.Quantity",
+              "fqn": "obf.datatype.Quantity",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.MammaprintRecurrenceScore"
             },
@@ -352,7 +352,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-MitoticCountScore.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-MitoticCountScore.json
@@ -20,7 +20,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -56,7 +56,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -69,7 +69,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"
@@ -86,7 +86,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/shr/oncology/vs/NottinghamNullVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-MorphologyBehavior.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-MorphologyBehavior.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A description of the morphology and behavioral characteristics of the cancer.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-NuclearPleomorphismScore.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-NuclearPleomorphismScore.json
@@ -20,7 +20,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -56,7 +56,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -69,7 +69,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"
@@ -86,7 +86,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/shr/oncology/vs/NottinghamNullVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-NuclearPositivity.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-NuclearPositivity.json
@@ -13,7 +13,7 @@
     "cimi.topic.EvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.PercentageRange",
+    "fqn": "obf.datatype.PercentageRange",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-OncotypeDxDCISRecurrenceScore.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-OncotypeDxDCISRecurrenceScore.json
@@ -133,9 +133,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -170,7 +170,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -292,16 +292,16 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.Quantity",
+              "fqn": "obf.datatype.Quantity",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.OncotypeDxDCISRecurrenceScore"
             },
             "subpaths": {
-              "shr.core.Quantity": {
+              "obf.datatype.Quantity": {
                 "subpaths": {
-                  "shr.core.Units": {
+                  "obf.datatype.Units": {
                     "subpaths": {
-                      "shr.core.Coding": {
+                      "obf.datatype.Coding": {
                         "fixedValue": {
                           "type": "code",
                           "value": {
@@ -319,7 +319,7 @@
           },
           "cimi.context.Interpretation": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/OncotypeDxDCISRiskScoreInterpretationVS",
                   "bindingStrength": "REQUIRED",
@@ -368,7 +368,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.Quantity",
+              "fqn": "obf.datatype.Quantity",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.OncotypeDxDCISRecurrenceScore"
             },
@@ -385,7 +385,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-OncotypeDxInvasiveRecurrenceScore.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-OncotypeDxInvasiveRecurrenceScore.json
@@ -133,9 +133,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -170,7 +170,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -292,16 +292,16 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.Quantity",
+              "fqn": "obf.datatype.Quantity",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.OncotypeDxInvasiveRecurrenceScore"
             },
             "subpaths": {
-              "shr.core.Quantity": {
+              "obf.datatype.Quantity": {
                 "subpaths": {
-                  "shr.core.Units": {
+                  "obf.datatype.Units": {
                     "subpaths": {
-                      "shr.core.Coding": {
+                      "obf.datatype.Coding": {
                         "fixedValue": {
                           "type": "code",
                           "value": {
@@ -319,7 +319,7 @@
           },
           "cimi.context.Interpretation": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/OncotypeDxInvasiveRiskScoreInterpretationVS",
                   "bindingStrength": "REQUIRED",
@@ -368,7 +368,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.Quantity",
+              "fqn": "obf.datatype.Quantity",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.OncotypeDxInvasiveRecurrenceScore"
             },
@@ -385,7 +385,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-ProgesteroneReceptorStatus.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-ProgesteroneReceptorStatus.json
@@ -133,9 +133,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -170,7 +170,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -327,12 +327,12 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.ProgesteroneReceptorStatus"
             },
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/PositiveNegativeVS",
                   "bindingStrength": "REQUIRED",
@@ -368,7 +368,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.ProgesteroneReceptorStatus"
             },
@@ -385,7 +385,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-ProsignaRecurrenceScore.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-ProsignaRecurrenceScore.json
@@ -133,9 +133,9 @@
           "lastModifiedBy": "cimi.statement.EvaluationResultRecorded"
         },
         "subpaths": {
-          "shr.core.Category": {
+          "obf.datatype.Category": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -170,7 +170,7 @@
           },
           "cimi.topic.TopicCode": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "fixedValue": {
                   "type": "code",
                   "value": {
@@ -292,16 +292,16 @@
         "subpaths": {
           "cimi.context.ResultValue": {
             "type": {
-              "fqn": "shr.core.Quantity",
+              "fqn": "obf.datatype.Quantity",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.ProsignaRecurrenceScore"
             },
             "subpaths": {
-              "shr.core.Quantity": {
+              "obf.datatype.Quantity": {
                 "subpaths": {
-                  "shr.core.Units": {
+                  "obf.datatype.Units": {
                     "subpaths": {
-                      "shr.core.Coding": {
+                      "obf.datatype.Coding": {
                         "fixedValue": {
                           "type": "code",
                           "value": {
@@ -319,7 +319,7 @@
           },
           "cimi.context.Interpretation": {
             "subpaths": {
-              "shr.core.CodeableConcept": {
+              "obf.datatype.CodeableConcept": {
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/shr/oncology/vs/RecurrenceRiskScoreInterpretationVS",
                   "bindingStrength": "REQUIRED",
@@ -368,7 +368,7 @@
           },
           {
             "constraint": {
-              "fqn": "shr.core.Quantity",
+              "fqn": "obf.datatype.Quantity",
               "onValue": true,
               "lastModifiedBy": "shr.oncology.ProsignaRecurrenceScore"
             },
@@ -385,7 +385,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "fixedValue": {
               "type": "code",
               "value": {

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-StageSuffix.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-StageSuffix.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A suffix used in conjuction with certain breast cancer stages, based on criteria defined by the staging system being used.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-StageTimingPrefix.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-StageTimingPrefix.json
@@ -14,7 +14,7 @@
     }
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-oncology/shr-oncology-TubuleFormationScore.json
+++ b/test/fixtures/cimcore/shr-oncology/shr-oncology-TubuleFormationScore.json
@@ -21,7 +21,7 @@
     "cimi.topic.CodedEvaluationComponent"
   ],
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,
@@ -57,7 +57,7 @@
       },
       "constraints": {
         "type": {
-          "fqn": "shr.core.CodeableConcept",
+          "fqn": "obf.datatype.CodeableConcept",
           "onValue": true,
           "lastModifiedBy": "cimi.topic.CodedEvaluationComponent"
         }
@@ -70,7 +70,7 @@
         "type": [
           {
             "constraint": {
-              "fqn": "shr.core.CodeableConcept",
+              "fqn": "obf.datatype.CodeableConcept",
               "onValue": true
             },
             "source": "cimi.topic.CodedEvaluationComponent"
@@ -87,7 +87,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/shr/oncology/vs/NottinghamNullVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-research/mappings/Study-mapping.json
+++ b/test/fixtures/cimcore/shr-research/mappings/Study-mapping.json
@@ -9,7 +9,7 @@
     "fieldMapping": [
       {
         "sourcePath": [
-          "shr.core.Title"
+          "obf.datatype.Title"
         ],
         "target": "title",
         "lastModifiedBy": "shr.research.Study"
@@ -44,7 +44,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.EffectiveTimePeriod"
+          "obf.datatype.EffectiveTimePeriod"
         ],
         "target": "period",
         "lastModifiedBy": "shr.research.Study"
@@ -65,7 +65,7 @@
       },
       {
         "sourcePath": [
-          "shr.core.ContactDetail"
+          "obf.datatype.ContactDetail"
         ],
         "target": "contact",
         "lastModifiedBy": "shr.research.Study"
@@ -101,7 +101,7 @@
       {
         "sourcePath": [
           "shr.research.StudyArm",
-          "shr.core.Title"
+          "obf.datatype.Title"
         ],
         "target": "arm.name",
         "lastModifiedBy": "shr.research.Study"
@@ -109,7 +109,7 @@
       {
         "sourcePath": [
           "shr.research.StudyArm",
-          "shr.core.Type"
+          "obf.datatype.Type"
         ],
         "target": "arm.code",
         "lastModifiedBy": "shr.research.Study"
@@ -117,7 +117,7 @@
       {
         "sourcePath": [
           "shr.research.StudyArm",
-          "shr.core.Details"
+          "obf.datatype.Details"
         ],
         "target": "arm.description",
         "lastModifiedBy": "shr.research.Study"

--- a/test/fixtures/cimcore/shr-research/shr-research-Jurisdiction.json
+++ b/test/fixtures/cimcore/shr-research/shr-research-Jurisdiction.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "The country, state or other region taking legal responsibility for the conduct of the study.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/cimcore/shr-research/shr-research-ResearchSubject.json
+++ b/test/fixtures/cimcore/shr-research/shr-research-ResearchSubject.json
@@ -80,7 +80,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/shr/research/vs/ResearchSubjectTerminationReasonVS",
               "bindingStrength": "REQUIRED",

--- a/test/fixtures/cimcore/shr-research/shr-research-Study.json
+++ b/test/fixtures/cimcore/shr-research/shr-research-Study.json
@@ -17,7 +17,7 @@
   ],
   "fields": [
     {
-      "fqn": "shr.core.Title",
+      "fqn": "obf.datatype.Title",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -33,7 +33,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -109,7 +109,7 @@
       }
     },
     {
-      "fqn": "shr.core.EffectiveTimePeriod",
+      "fqn": "obf.datatype.EffectiveTimePeriod",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -133,7 +133,7 @@
       }
     },
     {
-      "fqn": "shr.core.ContactDetail",
+      "fqn": "obf.datatype.ContactDetail",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0

--- a/test/fixtures/cimcore/shr-research/shr-research-StudyArm.json
+++ b/test/fixtures/cimcore/shr-research/shr-research-StudyArm.json
@@ -8,7 +8,7 @@
   "description": "Arm refers to pre-specified group or subgroup of participant(s) in a clinical trial assigned to receive specific intervention(s) (or no intervention) according to a protocol.",
   "fields": [
     {
-      "fqn": "shr.core.Title",
+      "fqn": "obf.datatype.Title",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 1,
@@ -16,7 +16,7 @@
       }
     },
     {
-      "fqn": "shr.core.Type",
+      "fqn": "obf.datatype.Type",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,
@@ -24,7 +24,7 @@
       },
       "constraints": {
         "subpaths": {
-          "shr.core.CodeableConcept": {
+          "obf.datatype.CodeableConcept": {
             "valueSet": {
               "uri": "http://standardhealthrecord.org/shr/research/vs/StudyArmTypeVS",
               "bindingStrength": "REQUIRED",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "fqn": "shr.core.Details",
+      "fqn": "obf.datatype.Details",
       "valueType": "IdentifiableValue",
       "card": {
         "min": 0,

--- a/test/fixtures/cimcore/shr-research/shr-research-TerminationReason.json
+++ b/test/fixtures/cimcore/shr-research/shr-research-TerminationReason.json
@@ -7,7 +7,7 @@
   "isAbstract": false,
   "description": "A description and/or code explaining the premature termination of the study.",
   "value": {
-    "fqn": "shr.core.CodeableConcept",
+    "fqn": "obf.datatype.CodeableConcept",
     "valueType": "IdentifiableValue",
     "card": {
       "min": 1,

--- a/test/fixtures/dataElement/UnitConstraintOnField.txt
+++ b/test/fixtures/dataElement/UnitConstraintOnField.txt
@@ -1,6 +1,6 @@
 Grammar:   DataElement 6.0
 Namespace: unitConstraintOnField
-Uses:      shr.core
+Uses:      obf.datatype
 
 CodeSystem:		  UCUM = http://unitsofmeasure.org
 

--- a/test/fixtures/dataElement/UnitConstraintOnFieldChild.txt
+++ b/test/fixtures/dataElement/UnitConstraintOnFieldChild.txt
@@ -1,6 +1,6 @@
 Grammar:   DataElement 6.0
 Namespace: unitConstraintOnFieldChild
-Uses:      shr.core
+Uses:      obf.datatype
 
 CodeSystem:		  UCUM = http://unitsofmeasure.org
 

--- a/test/fixtures/dataElement/UnitConstraintOnValue.txt
+++ b/test/fixtures/dataElement/UnitConstraintOnValue.txt
@@ -1,6 +1,6 @@
 Grammar:   DataElement 6.0
 Namespace: unitConstraintOnValue
-Uses:      shr.core
+Uses:      obf.datatype
 
 CodeSystem:		  UCUM = http://unitsofmeasure.org
 

--- a/test/fixtures/dataElement/UnitConstraintOnValueChild.txt
+++ b/test/fixtures/dataElement/UnitConstraintOnValueChild.txt
@@ -1,6 +1,6 @@
 Grammar:   DataElement 6.0
 Namespace: unitConstraintOnValueChild
-Uses:      shr.core
+Uses:      obf.datatype
 
 CodeSystem:		  UCUM = http://unitsofmeasure.org
 

--- a/test/fixtures/dataElement/_dependencies/core.txt
+++ b/test/fixtures/dataElement/_dependencies/core.txt
@@ -1,5 +1,5 @@
 Grammar:    DataElement 6.0
-Namespace:  shr.core
+Namespace:  obf.datatype
 
 // These are just dummy (incomplete) definitions to satisfy common dependencies
 

--- a/test/fixtures/dataElement/_dependencies/core_vs.txt
+++ b/test/fixtures/dataElement/_dependencies/core_vs.txt
@@ -1,5 +1,5 @@
 Grammar:    ValueSet 5.0
-Namespace:  shr.core
+Namespace:  obf.datatype
 
 // These are just dummy value sets so that value set resolution works in the tests
 ValueSet:   CodingQualifierVS

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -340,12 +340,12 @@ describe('#importDataElement', () => {
     const specifications = importFixture(nspace, importDir);
     const entry = expectAndGetElement(specifications, nspace, 'UnitConstraintOnValue');
     expectCardOne(entry.value);
-    expectValue(entry.value, 'shr.core', 'Quantity');
+    expectValue(entry.value, 'obf.datatype', 'Quantity');
     expect(entry.value.constraints).to.have.length(1); // fails here
     expect(entry.value.constraints[0]).to.be.instanceof(CodeConstraint);
-//   expect(entry.value.constraints[0].path).to.eql([id('shr.core','Units'), id('shr.core','concept')]);
+//   expect(entry.value.constraints[0].path).to.eql([id('obf.datatype','Units'), id('obf.datatype','concept')]);
     expect(entry.value.constraints[0].path).to.have.length(2);
-    expect(entry.value.constraints[0].path).to.eql([id('shr.core','Units'), id('primitive', 'concept')]);
+    expect(entry.value.constraints[0].path).to.eql([id('obf.datatype','Units'), id('primitive', 'concept')]);
     expectConcept(entry.value.constraints[0].code, 'http://unitsofmeasure.org', 'dl', 'DeciLiter');
   });
 
@@ -358,9 +358,9 @@ describe('#importDataElement', () => {
     expectValue(entry.value, nspace, 'Volume');
     expect(entry.value.constraints).to.have.length(1);  // fails here
     expect(entry.value.constraints[0]).to.be.instanceof(CodeConstraint);
-  // expect(entry.value.constraints[0].path).to.eql([id('shr.core', 'Quantity'), id('shr.core', 'Units'), id('shr.core', 'concept')]);
+  // expect(entry.value.constraints[0].path).to.eql([id('obf.datatype', 'Quantity'), id('obf.datatype', 'Units'), id('obf.datatype', 'concept')]);
     expect(entry.value.constraints[0].path).to.have.length(3);
-    expect(entry.value.constraints[0].path).to.eql([id('shr.core', 'Quantity'), id('shr.core', 'Units'), id('primitive', 'concept')]);
+    expect(entry.value.constraints[0].path).to.eql([id('obf.datatype', 'Quantity'), id('obf.datatype', 'Units'), id('primitive', 'concept')]);
     expectConcept(entry.value.constraints[0].code, 'http://unitsofmeasure.org', 'dl', 'DeciLiter');
   });
 
@@ -373,12 +373,12 @@ describe('#importDataElement', () => {
     expect(group.description).to.equal('It is a group entry with a unit constraint on a field');
     expect(group.value).to.be.undefined;
     expect(group.fields).to.have.length(1);
-    expectField(group, 0, 'shr.core', 'Quantity', 0, 1);
+    expectField(group, 0, 'obf.datatype', 'Quantity', 0, 1);
     const el = group.fields[0];
     expect(el.constraints).to.have.length(1);
     expect(el.constraints[0]).to.be.instanceof(CodeConstraint);
-//    expect(el.constraints[0].path).to.eql([id('shr.core','Units'), id('shr.core','concept')]);
-    expect(el.constraints[0].path).to.eql([id('shr.core','Units'), pid('concept')]);
+//    expect(el.constraints[0].path).to.eql([id('obf.datatype','Units'), id('obf.datatype','concept')]);
+    expect(el.constraints[0].path).to.eql([id('obf.datatype','Units'), pid('concept')]);
     expectConcept(el.constraints[0].code, 'http://unitsofmeasure.org', 'dl', 'DeciLiter');
   });
 
@@ -394,8 +394,8 @@ describe('#importDataElement', () => {
     const el = group.fields[0];
     expect(el.constraints).to.have.length(1);
     expect(el.constraints[0]).to.be.instanceof(CodeConstraint);
-//    expect(el.constraints[0].path).to.eql([id('shr.core', 'Quantity'), id('shr.core', 'Units'), id('shr.core', 'concept')]);
-    expect(el.constraints[0].path).to.eql([id('shr.core', 'Quantity'), id('shr.core', 'Units'), pid('concept')]);
+//    expect(el.constraints[0].path).to.eql([id('obf.datatype', 'Quantity'), id('obf.datatype', 'Units'), id('obf.datatype', 'concept')]);
+    expect(el.constraints[0].path).to.eql([id('obf.datatype', 'Quantity'), id('obf.datatype', 'Units'), pid('concept')]);
     expectConcept(el.constraints[0].code, 'http://unitsofmeasure.org', 'dl', 'DeciLiter');
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,9 +906,9 @@ shr-expand@^6.0.0:
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0.tgz#a2072f971e19b9f221e012c0056ee389a78633d7"
   integrity sha512-zzjli5uVY23J4jHnr5Cr+iLkZ7+6RsHk3kQMksBPUR4ly96NXlCRgillJ3IszbdP3dHpBuWymcrAOjyz4C/lRA==
 
-shr-models@standardhealth/shr-models#add-fixed-value-constraint:
+shr-models@standardhealth/shr-models#cm_sprint_41:
   version "6.1.0"
-  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/e045a21cae9632e0633b6bdab2f77e36dfa16f29"
+  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/020a549c5b52f2c06a23d63a120a179c6510a381"
 
 shr-test-helpers@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This PR changes many of the test fixtures to use the new `obf.datatype` namespace rather than `shr.core`.  There are no changes to actual production code.

PR 2 of 4.