### PR TITLE
Decentralize loggerific errorMessages.txt

### DIFF
--- a/errorMessages.txt
+++ b/errorMessages.txt
@@ -1,0 +1,80 @@
+Number, Message, Solution, deduplicationKeys
+01001, 'No project configuration file found - currently using default EXAMPLE identifiers. Auto-generating a proper config.json in your specifications folder', 'Open the config.json file and customize it for your project.', 'errorNumber'
+01002, 'Config file missing key: ${key} using default value: ${defaultValue} instead.', ' Open the config.json file and add your project specific details for that key.', 'errorNumber'
+01003, 'Unknown Filetype: ${fileType}',,
+01004, 'Start importing content profile file',,
+01005, 'Done importing content profile file',,
+01006, 'Entered content profile file',,
+01007, 'Exiting content profile file',,
+01008, 'Start importing data elements file',,
+01009, 'Done importing data elements file',,
+01010, 'Start importing data element',,
+01011, 'Done importing data element',,
+01012, 'Using config file ${configFile}',,
+01013, 'Start importing mapping file',,
+01014, 'Done importing mapping file',,
+01015, 'Start importing namespace mapping',,
+01016, 'Done importing namespace mapping',,
+01017, 'Start importing element mapping',,
+01018, 'Done importing element mapping',,
+01019, 'Configuration file "${oldPropertyName}" field will be deprecated. Use "implementationGuide.${igPropertyName}" instead.', 'Replace old propery path with new property path',
+01020, 'Start preprocessing data elements file',,
+01021, 'Done preprocessing data elements file',,
+01022, 'Start importing value set file',,
+01023, 'Done importing value set file',,
+01024, 'Start importing data element namespace',,
+01025, 'Done importing data element namespace',,
+01026, 'Start preprocessing namespace',,
+01027, 'Done preprocessing namespace',,
+01028, 'Start importing value set namespace',,
+01029, 'Done importing value set namespace',,
+11001, 'Element name "${name}" should begin with a capital letter', 'Rename the specified Element', 'errorNumber'
+11002, 'Entry name '${name}' should begin with a capital letter' , 'Rename the specified Entry', 'errorNumber'
+11003, 'Unable to resolve value set reference: ${valueSet}', 'Invalid value set reference double check the name and the path', 'errorNumber'
+11004, 'Unsupported binding strength: ${bindingStrength}. Defaulting to REQUIRED', 'Binding strength has to be one of the following: -mus be' (required) -mus be X if covered' (extensible) should be' (preferred) could be' (optional)', 'errorNumber'
+11005, 'Error parsing source path: ${path1}', 'Invalid path to definitions. Double check path.', 'errorNumber'
+11006, 'Invalid config file. Should be valid JSON dictionary', 'Make sure your 'config.json' file is using a valid format for JSON.', 'errorNumber'
+11007, 'Unsupported grammar version: ${versionMajor}.${versionMinor} ', 'Grammar Version for file must be 5.0 (or above)', 'errorNumber'
+11008, 'Defining value sets by URL has been deprecated in ValueSet files. ValueSet ${valueSet1} ignored.', 'Define the value set with a name using proper syntax.', 'errorNumber'
+11009, 'Defining value sets by URN has been deprecated in ValueSet files. ValueSet ${valueSet1} ignored.', 'Define the value set with a name using proper syntax.', 'errorNumber'
+11010, 'Could not resolve code system for alias: ${alias1}', 'Invalid Codesystem double check spelling', 'errorNumber'
+11011, 'Uses statements have been deprecated in ValueSet files. Uses statement ignored.', 'Uses statement is unnecessary. Refer to documentation for proper syntax', 'errorNumber'
+11012, 'Only default path definitions are allowed in ValueSet files. Path definition ignored.', 'Use one of the preset path definitions defined in the documentation.', 'errorNumber'
+11015, '${message}', 'This is usually a typo issue. Investigate keywords and missing colons around the specificed text input.', 'errorNumber'
+11016, '${message}', 'This is usually a typo issue. Investigate spelling and keywords used around the specificied text input.', 'errorNumber'
+11017, '${message}', 'This is usually a typo issue. Investigate spelling and keywords used around the specificied text input.', 'errorNumber'
+11020, 'Failed to resolve vocabulary for ${name}.', 'Unknown', 'errorNumber'
+11023, '${message}', 'This is usually a typo issue. Investigate spelling and keywords used around the specificied text input.', 'errorNumber'
+11025, 'Fields cannot be constrained to type ${value} ', 'Unknown', 'errorNumber'
+11027, 'Unable to import property ${fqn1}  unknown value type: ${valueType1}', 'The type either does not exist  or the import tool needs to be updated.', 'errorNumber'
+11028, 'Unable to import unknown constraint type: ${constraintType1} ', 'The type either does not exist  or the import tool needs to be updated.', 'errorNumber'
+11029, 'Unable to import mapping. Unknown rule type: ${ruleType}', 'The type either does not exist  or the import tool needs to be updated.', 'errorNumber'
+11030, 'Unable to import VS rule  unknown rule type: ${ruleType1}', 'The type either does not exist  or the import tool needs to be updated.', 'errorNumber'
+11031, 'Unable to import FixedValueConstraint unknown fixed value type: ${ruleType1}', 'The value type either does not exist  or the import tool needs to be updated.', 'errorNumber'
+11032, 'Project configuration not found! Exiting the program.', 'There was an error finding or loading the project.json configuration file. Please double check that it exists and is valid.', 'errorNumber'
+11033, 'Name ${elementEntryName} already exists.', 'The entity or element name already exists within the namespace and the most recently defined element or entry name will be used.', 'errorNumber'
+11034, 'ValueSet name ${vsName} already exists.', 'The value set name already exists within the namespace.', 'errorNumber'
+11035, 'Elements cannot be based on ${value} keyword', 'Unknown', 'errorNumber'
+11036, 'Path not found for ${identifier}: ${path}', 'Unknown', 'errorNumber'
+11037, 'Definition not found for data element in content profile path: ${cpProfilePath}', 'Unknown', 'errorNumber'
+11038, 'Could not find content profile file: ${cpFile}', 'Unknown', 'errorNumber'
+11039, 'Grammar declaration not found', 'Add Grammar declaration at top of file', 'errorNumber'
+11040, 'Property "${name}" already exists.', 'Remove or rename redundant property', 'errorNumber'
+11041, 'Choice value constrained without specifying the specific choice', 'Specify the choice to constrain using []', 'errorNumber'
+11042, 'Constraint refers to previous identifier', 'Unknown', 'errorNumber'
+11043, 'Value should not declare cardinality', 'Remove cardinality from value declaration', 'errorNumber'
+11044, 'Missing a value element', 'Unknown', 'errorNumber'
+11045, 'Invalid file ${fileName1} ',  'Unknown', 'errorNumber'
+11046, 'Invalid config file: ${configFilename1} ',  'Unknown', 'errorNumber'
+11047, 'Resolution error: ${errorText} ',  '(1) Check your Uses declaration to make sure you are importing the namespace of the class, (2) check the spelling of the class name, (3) check if the class is defined. This message could also be result of a syntax error.', 'errorNumber'
+11048, 'Cannot resolve element definition for ${elementFqn}', 'Unknown', 'errorNumber'
+11049, 'Namespace declaration not found', 'Add Namespace declaration to file', 'errorNumber'
+11050, 'Entry ${entry} cannot declare ${parent} as its parent since ${parent} is not an Entry or Abstract', '(1) Make sure the parent class is an Entry or Abstract class, (2) Check that the parent class exists, and you didn't misspell the class name, (3) Check your Uses declaration to make sure you are importing the namespace of the parent class, if it is in a different namespace.' , 'errorNumber'
+11051, 'Abstract ${abstract} cannot declare ${parent} as its parent since ${parent} is not an Abstract', 'Unknown', 'errorNumber'
+11052, 'Group ${group} cannot declare ${parent} as its parent since ${parent} is not a Group', 'Unknown', 'errorNumber'
+11053, 'Element ${element} cannot declare ${parent} as its parent since ${parent} is not an Element', 'Unknown', 'errorNumber'
+11054, 'Cannot declare Value on a non-Element', 'Unknown', 'errorNumber'
+11055, 'Cannot redeclare Value on Element that has a parent. Constrain Value instead.', 'Unknown', 'errorNumber'
+11056, 'Cannot declare properties on an Element since Elements do not have properties', 'Unknown', 'errorNumber'
+11057, 'Cannot constrain Value on a non-Element since non-Elements do not have Values', 'Unknown', 'errorNumber'
+11058, 'Cannot constrain properties on Elements since Elements only have Values', 'Unknown', 'errorNumber'

--- a/lib/cimcore/cimcoreImport.js
+++ b/lib/cimcore/cimcoreImport.js
@@ -92,11 +92,13 @@ class CimcoreImporter {
         this.nsConstructor.add(file);
         break;
       default:
-        logger.warn('Unknown Filetype: ', file.fileType);
+        // 01003, 'Unknown Filetype: ${fileType}',,
+        logger.warn({ fileType: file.fileType }, '01003');
         break;
       }
     } else {
-      logger.error('Invalid file: %s', file);
+      //11045, 'Invalid file ${fileName1} ' ,  'Unknown' , 'errorNumber'
+      logger.error({fileName1 : file}, '11045' );
     }
   }
 

--- a/lib/cimcore/constructors/dataElementConstructor.js
+++ b/lib/cimcore/constructors/dataElementConstructor.js
@@ -99,7 +99,8 @@ class DataElementConstructor {
       break;
     }
     default:
-      logger.error('Unable to import property %s, unknown value type: %s ERROR_CODE:11027', de.fqn, value.valueType);
+      //11027 , 'Unable to import property ${fqn1}  unknown value type: ${valueType1}' , 'The type either does not exist  or the import tool needs to be updated.', 'errorNumber'
+      logger.error({fqn1 : de.fqn, valueType1 : value.valueType }, '11027');
       return;
     }
 
@@ -201,7 +202,8 @@ class DataElementConstructor {
       this.constructSubpaths(constraint, path, aggregate);
       break;
     default:
-      logger.error('Unable to import unknown constraint type: %s ERROR_CODE:11028', cType);
+      //11028 , 'Unable to import unknown constraint type: ${constraintType1} ' , 'The type either does not exist  or the import tool needs to be updated.', 'errorNumber'
+      logger.error({constraintType1 : cType }, '11028' );
       break;
     }
 
@@ -243,7 +245,8 @@ class DataElementConstructor {
       if (constraint.lastModifiedBy) fixedValueConstraint.lastModifiedBy = idFromFQN(constraint.lastModifiedBy);
       return fixedValueConstraint;
     } else {
-      logger.error('Unable to import FixedValueConstraint, unknown fixed value type: %s ERROR_CODE:11031', constraint.type);
+      //11031 , 'Unable to import FixedValueConstraint unknown fixed value type: ${ruleType1}' , 'The value type either does not exist  or the import tool needs to be updated.', 'errorNumber'
+      logger.error({ruleType1 :  constraint.type }, '11031' );
     }
   }
 

--- a/lib/cimcore/constructors/mappingConstructor.js
+++ b/lib/cimcore/constructors/mappingConstructor.js
@@ -76,7 +76,8 @@ class MappingConstructor {
         constructFixedValueMappingRules(rules);
         break;
       default:
-        logger.error('Unable to import mapping, unknown rule type: %s ERROR_CODE:11029', rType);
+        //12029 , 'Cannot resolve element definition for ${name1}' , 'This is due to a incomplete definition for an element. Please refer to the document for proper definition syntax.', 'errorNumber'
+        logger.error({name1 :  rType }, '11029' );
         break;
       }
     }

--- a/lib/cimcore/constructors/mappingConstructor.js
+++ b/lib/cimcore/constructors/mappingConstructor.js
@@ -76,7 +76,7 @@ class MappingConstructor {
         constructFixedValueMappingRules(rules);
         break;
       default:
-        //12029 , 'Cannot resolve element definition for ${name1}' , 'This is due to a incomplete definition for an element. Please refer to the document for proper definition syntax.', 'errorNumber'
+        // 11029, 'Unable to import mapping. Unknown rule type: ${ruleType}', 'The type either does not exist  or the import tool needs to be updated.', 'errorNumber'
         logger.error({name1 :  rType }, '11029' );
         break;
       }

--- a/lib/cimcore/constructors/valueSetConstructor.js
+++ b/lib/cimcore/constructors/valueSetConstructor.js
@@ -118,7 +118,8 @@ class ValueSetConstructor {
         constructExcludesDescendentsRules(rules);
         break;
       default:
-        logger.error('Unable to import VS rule, unknown rule type: %s ERROR_CODE:11030', rType);
+        //11030 , 'Unable to import VS rule  unknown rule type: ${ruleType1}' , 'The type either does not exist  or the import tool needs to be updated.', 'errorNumber'
+        logger.error({ruleType1 : rType }, '11030');
         break;
       }
     }

--- a/lib/contentProfileListener.js
+++ b/lib/contentProfileListener.js
@@ -34,7 +34,8 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
     // Setup a child logger to associate logs with the current file
     const lastLogger = logger;
     logger = rootLogger.child({ file: file });
-    logger.debug('Start importing content profile file');
+    // 01004, 'Start importing content profile file',,
+    logger.debug('01004');
     try {
       const errListener = new SHRErrorListener(logger);
       const chars = new FileStream(file);
@@ -50,7 +51,8 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
       const walker = new ParseTreeWalker();
       walker.walk(this, tree);
     } finally {
-      logger.debug('Done importing content profile file');
+      // 01005, 'Done importing content profile file',,
+      logger.debug('01005');
       this.logger = lastLogger;
     }
   }
@@ -62,12 +64,14 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
     const minor = parseInt(version.WHOLE_NUMBER()[1], 10);
     this._currentGrammarVersion = new Version(major, minor);
 
-    logger.debug({version: this._currentGrammarVersion.toString()}, 'Entered content profile file');
+    // 01006, 'Entered content profile file',,
+    logger.debug('01006');
   }
 
   exitDoc(ctx) {
     // clear current namespace, current content, current rule, and grammar version
-    logger.debug('Exiting content profile file');
+    // 01007, 'Exiting content profile file',,
+    logger.debug('01007');
     this._currentNs = null;
     this._currentDef = null;
     this._currentRule = null;
@@ -196,10 +200,8 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
         }
       }
     } else {
-      logger.error(
-        'Definition not found for data element in content profile path: %s. ERROR_CODE:11035',
-        this._currentDef.identifier.fqn
-      );
+      // 11037, 'Definition not found for data element in content profile path: ${cpProfilePath}', 'Unknown', 'errorNumber'
+      logger.error({ cpProfilePath: this._currentDef.identifier.fqn }, '11037');
     }
 
     if (path.length === names.length) {
@@ -207,7 +209,8 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
     } else {
       // TODO: We may be able to help the author by suggesting fixes when the problem is that they referred to the old identifier instead of the effectiveIdentifier.
       // This will require some rework of the above code to detect and remember this situation.
-      logger.error('Path not found for %s: %s. ERROR_CODE:11036', this._currentDef.identifier.fqn, pathStr);
+      // 11036, 'Path not found for ${identifier}: ${path}', 'Unknown', 'errorNumber'
+      logger.error({ identifier: this._currentDef.identifier.fqn, path: pathStr }, '11036');
     }
   }
 
@@ -240,7 +243,8 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
     // We haven't processed it, so look it up
     const element = this._specs.dataElements.findByIdentifier(identifier);
     if (typeof element === 'undefined') {
-      logger.error('Cannot resolve element definition for %s. ERROR_CODE:13023', identifier.fqn);
+      // 11048, 'Cannot resolve element definition for ${elementFqn}', 'Unknown', 'errorNumber'
+      logger.error({ elementFqn: identifier.fqn }, '11048');
       return alreadyProcessed;
     }
     // Add it to the already processed list (again, to avoid circular dependencies)

--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -41,7 +41,8 @@ class DataElementImporter extends SHRDataElementParserListener {
     // Setup a child logger to associate logs with the current file
     const lastLogger = logger;
     logger = rootLogger.child({ file: file });
-    logger.debug('Start importing data elements file');
+    // 01008, 'Start importing data elements file',,
+    logger.debug('01008');
     try {
       const errListener = new SHRErrorListener(logger);
       const chars = new FileStream(file);
@@ -57,7 +58,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       const walker = new ParseTreeWalker();
       walker.walk(this, tree);
     } finally {
-      logger.debug('Done importing data elements file');
+      // 01009, 'Done importing data elements file',,
+      logger.debug('01009');
       this.logger = lastLogger;
     }
   }
@@ -70,7 +72,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       ns = ctx.docHeader().namespace().getText();
     }
     else {
-      logger.error('Namespace declaration not found. ERROR_CODE:11038');
+      // 11049, 'Namespace declaration not found', 'Unknown', 'errorNumber'
+      logger.error('11049');
     }
     this._currentNs = ns;
     let nsDef = this._specs.namespaces.find(ns);
@@ -93,7 +96,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       logger.debug({shrId: ns, version: this._currentGrammarVersion.toString()}, 'Start importing data element namespace');
     }
     else {
-      logger.error('Grammar declaration not found. ERROR_CODE 11039');
+      // 11039, 'Grammar declaration not found', 'Add Grammar declaration at top of file', 'errorNumber'
+      logger.error('11039');
     }
   }
 
@@ -117,16 +121,21 @@ class DataElementImporter extends SHRDataElementParserListener {
     const lastLogger = logger;
     logger = logger.child({ shrId: id.fqn });
     logger.parent = lastLogger;
-    logger.debug('Start importing data element');
+    // 01010, 'Start importing data element',,
+    logger.debug('01010');
 
-    if (ctx.elementHeader().simpleName().LOWER_WORD()) { logger.error('Element name "%s" should begin with a capital letter. ERROR_CODE:11001', ctx.elementHeader().simpleName().getText()); }
+    if (ctx.elementHeader().simpleName().LOWER_WORD()) {
+      //11001 , 'Element name '${name}' should begin with a capital letter' , 'Rename the specified Element', 'errorNumber'
+      logger.error({name : ctx.elementHeader().simpleName().getText() }, '11001' );
+    }
   }
 
   exitElementDef(ctx) {
     try {
       this.pushCurrentDefinition();
     } finally {
-      logger.debug('Done importing data element');
+      // 01011, 'Done importing data element',,
+      logger.debug('01011');
       logger = logger.parent;
     }
   }
@@ -138,16 +147,21 @@ class DataElementImporter extends SHRDataElementParserListener {
     const lastLogger = logger;
     logger = logger.child({ shrId: id.fqn });
     logger.parent = lastLogger;
-    logger.debug('Start importing data element');
+    // 01010, 'Start importing data element',,
+    logger.debug('01010');
 
-    if (ctx.abstractHeader().simpleName().LOWER_WORD()) { logger.error('Element name "%s" should begin with a capital letter. ERROR_CODE:11001', ctx.elementHeader().simpleName().getText()); }
+    if (ctx.abstractHeader().simpleName().LOWER_WORD()) {
+      // 11001, 'Element name '${name}' should begin with a capital letter', 'Rename the specified Element', 'errorNumber'
+      logger.error({ name: ctx.elementHeader().simpleName().getText() }, '11001');
+    }
   }
 
   exitAbstractDef(ctx) {
     try {
       this.pushCurrentDefinition();
     } finally {
-      logger.debug('Done importing data element');
+      // 01011, 'Done importing data element',,
+      logger.debug('01011');
       logger = logger.parent;
     }
   }
@@ -160,16 +174,21 @@ class DataElementImporter extends SHRDataElementParserListener {
     const lastLogger = logger;
     logger = logger.child({ shrId: id.fqn });
     logger.parent = lastLogger;
-    logger.debug('Start importing data element');
+    // 01011, 'Done importing data element',,
+    logger.debug('01011');
 
-    if (ctx.groupHeader().simpleName().LOWER_WORD()) { logger.error('Element name "%s" should begin with a capital letter. ERROR_CODE:11001', ctx.groupHeader().simpleName().getText()); }
+    if (ctx.groupHeader().simpleName().LOWER_WORD()) {
+      // 11001, 'Element name '${name}' should begin with a capital letter', 'Rename the specified Element', 'errorNumber'
+      logger.error({ name: ctx.groupHeader().simpleName().getText() }, '11001');
+    }
   }
 
   exitGroupDef(ctx) {
     try {
       this.pushCurrentDefinition();
     } finally {
-      logger.debug('Done importing data element');
+      // 01011, 'Done importing data element',,
+      logger.debug('01011');
       logger = logger.parent;
     }
   }
@@ -182,16 +201,21 @@ class DataElementImporter extends SHRDataElementParserListener {
     const lastLogger = logger;
     logger = logger.child({ shrId: id.fqn });
     logger.parent = lastLogger;
-    logger.debug('Start importing data element');
+    // 01011, 'Done importing data element',,
+    logger.debug('01011');
 
-    if (ctx.entryHeader().simpleName().LOWER_WORD()) { logger.error('Entry Element name "%s" should begin with a capital letter. ERROR_CODE:11002', ctx.entryHeader().simpleName().getText()); }
+    if (ctx.entryHeader().simpleName().LOWER_WORD()) {
+      //11002 , 'Entry Element name '${name}' should begin with a capital letter' , 'Rename the specified EntryElement', 'errorNumber'
+      logger.error(  {name: ctx.entryHeader().simpleName().getText() }, '11002' );
+    }
   }
 
   exitEntryDef(ctx) {
     try {
       this.pushCurrentDefinition();
     } finally {
-      logger.debug('Done importing data element');
+      // 01011, 'Done importing data element',,
+      logger.debug('01011');
       logger = logger.parent;
     }
   }
@@ -199,7 +223,9 @@ class DataElementImporter extends SHRDataElementParserListener {
   enterParentProp(ctx) {
     const identifier = this.resolveToIdentifierOrTBD(ctx);
     if (identifier.isSpecialKeyWord) {
-      logger.error(`Elements cannot be based on "${identifier.name}" keyword. ERROR_CODE:11023`);
+      //11023 was a duplicate number; reassigned 11035
+      //11035 , 'Elements cannot be based on ${value} keyword' , 'Unknown', 'errorNumber'
+      logger.error({value: identifier.name } , '11035');
     } else {
       const parentInfo = this._preprocessedData.resolveDefinition(identifier.name, identifier.namespace);
       if (this._currentDef.isEntry) {
@@ -331,7 +357,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       if (cst.elementTypeConstraint()) {
         const newIdentifier = this.resolveToIdentifierOrTBD(cst.elementTypeConstraint());
         if (newIdentifier.isSpecialKeyWord) {
-          logger.error(`Fields cannot be constrained to type "${newIdentifier.name}". ERROR_CODE:11025`);
+          //11025 , 'Fields cannot be constrained to type ${value} ' , 'Unknown' , 'errorNumber'
+          logger.error( {value: newIdentifier.name }, '11025');
         } else {
           const onValue = cst.elementTypeConstraint().KW_ONLY() ? true : false;
           value.addConstraint(new TypeConstraint(newIdentifier, path, onValue));
@@ -340,7 +367,8 @@ class DataElementImporter extends SHRDataElementParserListener {
         for (const typeConstraint of cst.elementIncludesTypeConstraint().typeConstraint()) {
           const newIdentifier = this.resolveToIdentifierOrTBD(typeConstraint);
           if (newIdentifier.isSpecialKeyWord) {
-            logger.error(`Fields cannot be constrained to type "${newIdentifier.name}". ERROR_CODE:11025`);
+            //11025 , 'Fields cannot be constrained to type ${value} ' , 'Unknown' , 'errorNumber'
+            logger.error( {value: newIdentifier.name }, '11025');
           } else {
             [min, max] = this.getMinMax(typeConstraint.count());
             const isOnValue = (path.length > 0 && path[0].isValueKeyWord);
@@ -399,7 +427,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       }
       const field = this.processCountAndTypes(ctx.propertyField().count(), [ctx.propertyField().propertyFieldType()]);
       if (this._currentDef.fields.some(f => f.identifier && f.identifier.equals(field.identifier))) {
-        logger.error('Property "%s" already exists. ERROR_CODE:11040', field.identifier.name);
+        // 11040, 'Property "${name}" already exists.', 'Remove or rename redundant property', 'errorNumber'
+        logger.error({ name: field.identifier.name }, 'name');
       }
       else {
         this.addFieldToCurrentDef(field);
@@ -424,7 +453,8 @@ class DataElementImporter extends SHRDataElementParserListener {
               }
             });
             if(!marked) {
-              logger.error('Choice value constrained without specifying the specific choice. ERROR_CODE:11041');
+              // 11041, 'Choice value constrained without specifying the specific choice', 'Specify the choice to constrain using []', 'errorNumber'
+              logger.error('11041');
             }
           }
 
@@ -450,7 +480,8 @@ class DataElementImporter extends SHRDataElementParserListener {
         else {
           const secondMatch = this._currentDef.fields.find(f => f.identifier && f.identifier.equals(field.identifier));
           if (secondMatch) {
-            logger.error('Constraint refers to previous identifier. ERROR_CODE:11042');
+            // 11042, 'Constraint refers to previous identifier', 'Unknown', 'errorNumber'
+            logger.error('11042');
           }
           else {
             this.addFieldToCurrentDef(field);
@@ -533,10 +564,12 @@ class DataElementImporter extends SHRDataElementParserListener {
     }
     let match = typeCtxArr[0].getText().match(/\d+\.\.(\d+|\*)/);
     if (match) {
-      logger.error('Value should not be declaring cardinality. ERROR:11043');
+      // 11043, 'Value should not declare cardinality', 'Remove cardinality from value declaration', 'errorNumber'
+      logger.error('11043');
     }
     else if (typeCtxArr[0].getText().length == 0) {
-      logger.error('Missing a value element. ERROR:11044');
+      // 11044, 'Missing a value element', 'Unknown', 'errorNumber'
+      logger.error('11044');
     }
     else {
       return this.processType(typeCtxArr[0], 1, 1);
@@ -578,7 +611,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       const [path, name] =  vsConstraint.valueset().PATH_URL().getText().split('/', 2);
       const resolution = this._preprocessedData.resolvePath(path, this._currentNs, ...this._usesNs);
       if (resolution.error) {
-        logger.error(resolution.error);
+        //11047, 'Resolution error ${errorText} ' ,  'Unknown' , 'errorNumber'
+        logger.error({errorText : resolution.error }, '11047');
       }
       if (resolution.url) {
         vs = `${resolution.url}/${name}`;
@@ -596,7 +630,8 @@ class DataElementImporter extends SHRDataElementParserListener {
         }
       }
       if (!found) {
-        logger.error('Unable to resolve value set reference: %s. ERROR_CODE:11003', name);
+        //11003 , 'Unable to resolve value set reference: ${valueSet}' , 'Invalid value set reference  double check the name and the path', 'errorNumber'
+        logger.error({valueSet:  name}, '11003' );
         vs = `urn:tbd:${name}`;
       }
     } else if (vsConstraint.valueset().tbd()) {
@@ -622,7 +657,8 @@ class DataElementImporter extends SHRDataElementParserListener {
         return EXTENSIBLE;
       }
       // This error should never occur unless the ANTLR grammar changes
-      logger.error('Unsupported binding strength: %s.  Defaulting to REQUIRED. ERROR_CODE:11004', bindingCtx.getText());
+      //11004 , 'Unsupported binding strength: ${bindingStrength}. Defaulting to REQUIRED' , 'Binding strength has to be one of the following: -mus be' (required) -mus be X if covered' (extensible) should be' (preferred) could be' (optional)', 'errorNumber'
+      logger.error({ bindingStregth:  bindingCtx.getText() }, '11004' );
     }
     return REQUIRED;
   }
@@ -646,7 +682,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       const csAlias = ctx.ALL_CAPS().getText();
       const resolution = this._preprocessedData.resolveVocabulary(csAlias, this._currentNs, ...this._usesNs);
       if (resolution.error) {
-        logger.error(resolution.error);
+        //11047, 'Resolution error ${errorText} ' ,  'Unknown' , 'errorNumber'
+        logger.error({errorText : resolution.error }, '11047');
         cs = resolution.url ? resolution.url : csAlias;
       } else {
         cs = resolution.url;
@@ -699,7 +736,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       const name = ref.substr(lastDot+1);
       const resolution = this.resolveDefinition(name, ns);
       if (resolution.error) {
-        logger.error(resolution.error);
+        //11047, 'Resolution error ${errorText} ' ,  'Unknown' , 'errorNumber'
+        logger.error({errorText : resolution.error }, '11047');
       }
       return new Identifier(ns, name);
     }
@@ -715,7 +753,8 @@ class DataElementImporter extends SHRDataElementParserListener {
     var ns;
     const resolution = this.resolveDefinition(ref, this._currentNs, ...this._usesNs);
     if (resolution.error) {
-      logger.error(resolution.error);
+      //11047, 'Resolution error ${errorText} ' ,  'Unknown' , 'errorNumber'
+      logger.error({errorText : resolution.error }, '11047');
       ns = resolution.namespace ? resolution.namespace: 'unknown';
     } else {
       ns = resolution.namespace;
@@ -755,7 +794,8 @@ class DataElementImporter extends SHRDataElementParserListener {
 
   pushCurrentDefinition() {
     if (this._specs.dataElements.findByIdentifier(this._currentDef.identifier) != null) {
-      logger.error('Name "%s" already exists. ERROR_CODE:11033', this._currentDef.identifier.name);
+      //11033 , 'Name ${elementEntryName} already exists.' , 'The entity or element name already exists within the namespace and the most recently defined element or entry name will be used.', 'errorNumber'
+      logger.error( {elementEntryName : this._currentDef.identifier.name}, '11033');
     }
     this._specs.dataElements.add(this._currentDef, this._currentFile);
   }

--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -84,7 +84,7 @@ class DataElementImporter extends SHRDataElementParserListener {
     if (ctx.descriptionProp() && typeof nsDef.description === 'undefined') {
       nsDef.description = trimLines(stripDelimitersFromToken(ctx.descriptionProp().STRING()));
     }
-
+    
     // Process the version
     let docHeader = ctx.docHeader();
     if (docHeader.version()) {
@@ -93,7 +93,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       const minor = parseInt(version.WHOLE_NUMBER()[1], 10);
       this._currentGrammarVersion = new Version(major, minor);
 
-      logger.debug({shrId: ns, version: this._currentGrammarVersion.toString()}, 'Start importing data element namespace');
+      // 01024, 'Start importing data element namespace',,
+      logger.debug({shrId: ns, version: this._currentGrammarVersion.toString()}, '01024');
     }
     else {
       // 11039, 'Grammar declaration not found', 'Add Grammar declaration at top of file', 'errorNumber'
@@ -103,7 +104,8 @@ class DataElementImporter extends SHRDataElementParserListener {
 
   exitDoc(ctx) {
     // clear current namespace, uses namespaces, and grammar version
-    logger.debug({shrId: this._currentNs}, 'Done importing data element namespace');
+    // 01025, 'Done importing data element namespace ${ns}',,
+    logger.debug({shrId: this._currentNs}, '01025');
     this._currentNs = '';
     this._usesNs = [];
     this._currentGrammarVersion = null;
@@ -174,8 +176,8 @@ class DataElementImporter extends SHRDataElementParserListener {
     const lastLogger = logger;
     logger = logger.child({ shrId: id.fqn });
     logger.parent = lastLogger;
-    // 01011, 'Done importing data element',,
-    logger.debug('01011');
+    // 01010, 'Start importing data element',,
+    logger.debug('01010');
 
     if (ctx.groupHeader().simpleName().LOWER_WORD()) {
       // 11001, 'Element name '${name}' should begin with a capital letter', 'Rename the specified Element', 'errorNumber'
@@ -201,11 +203,11 @@ class DataElementImporter extends SHRDataElementParserListener {
     const lastLogger = logger;
     logger = logger.child({ shrId: id.fqn });
     logger.parent = lastLogger;
-    // 01011, 'Done importing data element',,
-    logger.debug('01011');
+    // 01010, 'Start importing data element',,
+    logger.debug('01010');
 
     if (ctx.entryHeader().simpleName().LOWER_WORD()) {
-      //11002 , 'Entry Element name '${name}' should begin with a capital letter' , 'Rename the specified EntryElement', 'errorNumber'
+      //11002 , 'Entry name '${name}' should begin with a capital letter' , 'Rename the specified Entry', 'errorNumber'
       logger.error(  {name: ctx.entryHeader().simpleName().getText() }, '11002' );
     }
   }
@@ -231,22 +233,26 @@ class DataElementImporter extends SHRDataElementParserListener {
       if (this._currentDef.isEntry) {
         // Entries can only inherit from another Entry or an Abstract
         if (parentInfo.type !== 'entry' && parentInfo.type !== 'abstract') {
-          logger.error('Entry %s cannot declare %s as its parent since %s is not an Entry or Abstract.  ERROR_CODE:11050', this._currentDef.identifier.name, identifier.name, identifier.name);
+          // 11050, 'Entry ${entry} cannot declare ${parent} as its parent since ${parent} is not an Entry or Abstract', 'Unknown', 'errorNumber'
+          logger.error({entry: this._currentDef.identifier.name, parent: identifier.name}, '11050');
         }
       } else if (this._currentDef.isAbstract) {
         // Abstracts can only inherit from another Abstract
         if (parentInfo.type !== 'abstract') {
-          logger.error('Abstract %s cannot declare %s as its parent since %s is not an Abstract.  ERROR_CODE:11051', this._currentDef.identifier.name, identifier.name, identifier.name);
+          // 11051, 'Abstract ${abstract} cannot declare ${parent} as its parent since ${parent} is not an Abstract', 'Unknown', 'errorNumber'
+          logger.error({abstract: this._currentDef.identifier.name, parent: identifier.name}, '11051');
         }
       } else if (this._currentDef.isGroup) {
         // Groups can only inherit from another Group
         if (parentInfo.type !== 'group') {
-          logger.error('Group %s cannot declare %s as its parent since %s is not a Group.  ERROR_CODE:11052', this._currentDef.identifier.name, identifier.name, identifier.name);
+          // 11052, 'Group ${group} cannot declare ${parent} as its parent since ${parent} is not a Group', 'Unknown', 'errorNumber'
+          logger.error({group: this._currentDef.identifier.name, parent: identifier.name}, '11052');
         }
       } else /* is an element */ {
         // Elements can only inherit from another Element
         if (parentInfo.type !== 'element') {
-          logger.error('Element %s cannot declare %s as its parent since %s is not an Element.  ERROR_CODE:11053', this._currentDef.identifier.name, identifier.name, identifier.name);
+          // 11053, 'Element ${element} cannot declare ${parent} as its parent since ${parent} is not an Element', 'Unknown', 'errorNumber'
+          logger.error({element: this._currentDef.identifier.name, parent: identifier.name}, '11053');
         }
       }
       this._currentDef.addBasedOn(identifier);
@@ -276,9 +282,11 @@ class DataElementImporter extends SHRDataElementParserListener {
     //    Check for ctx.COLON() because the grammar re-uses this rule for the KW_ONLY constraint too.
     //    NOTE: This check relies on the current grammar requiring parents be declared before values.
     if (this._currentDef.isGroup || this._currentDef.isEntry || this._currentDef.isAbstract) {
-      logger.error('Cannot declare Value on a non-Element.  ERROR_CODE:11054');
+      // 11054, 'Cannot declare Value on a non-Element', 'Unknown', 'errorNumber'
+      logger.error('11054');
     } else if (ctx.COLON() && this._currentDef.basedOn.length > 0) {
-      logger.error('Cannot redeclare Value on Element that has a parent.  Constrain Value instead.  ERROR_CODE:11055');
+      // 11055, 'Cannot redeclare Value on Element that has a parent. Constrain Value instead.', 'Unknown', 'errorNumber'
+      logger.error('11055');
     }
     const value = this.processCountAndTypesForValue(ctx);
     this._currentDef.value = value;
@@ -423,7 +431,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       // NOTE: This could potentially be enforced in the ANTLR grammar, but for now, we don't want
       // to make any changes in the grammar.  Consider changing in 6.1.
       if (isElement) {
-        logger.error('Cannot declare properties on an Element since Elements do not have properties.  ERROR_CODE:11056');
+        // 11056, 'Cannot declare properties on an Element since Elements do not have properties', 'Unknown', 'errorNumber'
+        logger.error('11056');
       }
       const field = this.processCountAndTypes(ctx.propertyField().count(), [ctx.propertyField().propertyFieldType()]);
       if (this._currentDef.fields.some(f => f.identifier && f.identifier.equals(field.identifier))) {
@@ -441,7 +450,8 @@ class DataElementImporter extends SHRDataElementParserListener {
         // NOTE: This could potentially be enforced in the ANTLR grammar, but for now, we don't want
         // to make any changes in the grammar.  Consider changing in 6.1.
         if (!isElement) {
-          logger.error('Cannot constrain Value on a non-Element since non-Elements do not have Values.  ERROR_CODE:11057');
+          // 11057, 'Cannot constrain Value on a non-Element since non-Elements do not have Values', 'Unknown', 'errorNumber'
+          logger.error('11057');
         }
         if (this._currentDef.value) {
           if (this._currentDef.value instanceof ChoiceValue) {
@@ -471,7 +481,8 @@ class DataElementImporter extends SHRDataElementParserListener {
         // NOTE: This could potentially be enforced in the ANTLR grammar, but for now, we don't want
         // to make any changes in the grammar.  Consider changing in 6.1.
         if (isElement) {
-          logger.error('Cannot constrain properties on Elements since Elements only have Values.  ERROR_CODE:11058');
+          // 11058, 'Cannot constrain properties on Elements since Elements only have Values', 'Unknown', 'errorNumber'
+          logger.error('11058');
         }
         const match = this._currentDef.fields.find(f => f.effectiveIdentifier && f.effectiveIdentifier.equals(field.identifier));
         if (match) {

--- a/lib/errorListener.js
+++ b/lib/errorListener.js
@@ -6,25 +6,16 @@ class SHRErrorListener extends ErrorListener {
     this._logger = bunyanLogger;
   }
 
-  codeMessage(msg) {
-    var code;
-
-    if (msg.match(/^extraneous input .+ expecting/)) {
-      code = 11023;
-    } else if (msg.match(/^mismatched input .+ expecting/)) {
-      code = 11016;
-    } else if (msg.match(/^token recognition error at: '.+'/)) {
-      code = 11015;
-    } else {
-      return msg;
-    }
-    
-    msg = `${msg}. ERROR_CODE:${code}`;
-    return msg;
-  }
-
   syntaxError(recognizer, offendingSymbol, line, column, msg, e) {
-    this._logger.error({line, column}, this.codeMessage(msg));
+    if (msg.match(/^extraneous input .+ expecting/)) {
+      this._logger.error({message: msg}, '11023');
+    } else if (msg.match(/^mismatched input .+ expecting/)) {
+      this._logger.error({message: msg}, '11016');
+    } else if (msg.match(/^token recognition error at: '.+'/)) {
+      this._logger.error({message: msg}, '11015');
+    } else {
+      this._logger.error({message: msg}, '11017');
+    }
   }
 }
 

--- a/lib/import.js
+++ b/lib/import.js
@@ -112,6 +112,10 @@ function processPath(filePath, filesByType = new FilesByType()) {
   return filesByType;
 }
 
+function errorFilePath() {
+  return require('path').join(__dirname, '..', 'errorMessages.txt');
+}
+
 class FilesByType {
   constructor() {
     this._contentProfile = [];
@@ -177,4 +181,4 @@ class FilesByType {
   }
 }
 
-module.exports = {importFromFilePath, importConfigFromFilePath, importCIMCOREFromFilePath, VERSION, GRAMMAR_VERSION, setLogger, MODELS_INFO};
+module.exports = {importFromFilePath, importConfigFromFilePath, importCIMCOREFromFilePath, errorFilePath, VERSION, GRAMMAR_VERSION, setLogger, MODELS_INFO};

--- a/lib/import.js
+++ b/lib/import.js
@@ -49,7 +49,8 @@ function importFromFilePath(filePath, configuration=[], specifications = new Spe
     }
   }
   if (configuration && configuration.contentProfile && !contentProfileFound) {
-    logger.error('Could not find content profile file: %s. ERROR_CODE:11037', configuration.contentProfile);
+    //11038, 'Could not find content profile file: ${cpFile}', 'Unknown', 'errorNumber'
+    logger.error({cpfile: configuration.contentProfile }, '11038');
   }
   return specifications;
 }
@@ -74,14 +75,16 @@ function importConfigFromFilePath(filePath, configName) {
   const validConfig = filesByType.config.some(f => path.resolve(f) === configFile);
 
   if (validConfig) {
-    logger.info('Using config file %s', configFile);
+    // 01012, 'Using config file ${configFile}',,
+    logger.info({ configFile }, '01012');
     configuration = preprocessor.preprocessConfig(defaultConfigFile, configFile);
   } else if ((configName == null || configName === 'config.json') && fs.statSync(filePath).isDirectory()) {
     const newFile = path.resolve(filePath, 'config.json');
     configuration = preprocessor.preprocessConfig(defaultConfigFile);
     fs.writeFileSync(newFile, defaultConfigFile, 'utf8');
   } else {
-    logger.error('Invalid config file: %s', configFile);
+    //11046, 'Invalid config file: ${configFilename1} ' ,  'Unknown' , 'errorNumber'
+    logger.error({configFilename1 : configFile}, '11046' );
   }
 
   return configuration;

--- a/lib/mappingListener.js
+++ b/lib/mappingListener.js
@@ -32,7 +32,8 @@ class MappingImporter extends SHRMapParserListener {
     // Setup a child logger to associate logs with the current file
     const lastLogger = logger;
     logger = rootLogger.child({ file: file });
-    logger.debug('Start importing mapping file');
+    // 01013, 'Start importing mapping file',,
+    logger.debug('01013');
     try {
       const errListener = new SHRErrorListener(logger);
       const chars = new FileStream(file);
@@ -48,7 +49,8 @@ class MappingImporter extends SHRMapParserListener {
       const walker = new ParseTreeWalker();
       walker.walk(this, tree);
     } finally {
-      logger.debug('Done importing mapping file');
+      // 01014, 'Done importing mapping file',,
+      logger.debug('01014');
       this.logger = lastLogger;
     }
   }
@@ -71,7 +73,8 @@ class MappingImporter extends SHRMapParserListener {
       targetSpec: this._currentTargetSpec,
       version: this._currentGrammarVersion.toString()
     };
-    logger.debug(info, 'Start importing namespace mapping');
+    // 01015, 'Start importing namespace mapping',,
+    logger.debug(info, '01015');
   }
 
   exitDoc(ctx) {
@@ -81,7 +84,8 @@ class MappingImporter extends SHRMapParserListener {
       targetSpec: this._currentTargetSpec,
       version: this._currentGrammarVersion.toString()
     };
-    logger.debug(info, 'Done importing namespace mapping');
+    // 01016, 'Done importing namespace mapping',,
+    logger.debug(info, '01016');
     this._currentNs = '';
     this._currentTargetSpec = '';
     this._currentGrammarVersion = null;
@@ -101,14 +105,16 @@ class MappingImporter extends SHRMapParserListener {
     const lastLogger = logger;
     logger = logger.child({ shrId: source.fqn, target: target });
     logger.parent = lastLogger;
-    logger.debug('Start importing element mapping');
+    // 01017, 'Start importing element mapping',,
+    logger.debug('01017');
   }
 
   exitMappingDef(ctx) {
     try {
       this.pushCurrentDefinition();
     } finally {
-      logger.debug('Done importing element mapping');
+      // 01018, 'Done importing element mapping',,
+      logger.debug('01018');
       logger = logger.parent;
     }
   }
@@ -148,7 +154,8 @@ class MappingImporter extends SHRMapParserListener {
             sourcePath.push(new TBD());
           }
         } else {
-          logger.error('Error parsing source path: %s. ERROR_CODE:11005', c.source().getText());
+          //11005 , 'Error parsing source path: ${path1}' , 'Invalid path to definitions. Double check path.', 'errorNumber'
+          logger.error({path1 : c.source().getText() }, '11005' );
         }
       }
     }
@@ -204,3 +211,4 @@ function stripDelimitersFromToken(tkn) {
 }
 
 module.exports = {MappingImporter, setLogger};
+

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -38,6 +38,7 @@ class Preprocessor extends SHRDataElementParserVisitor {
         return defaults;
       }
     } else {
+      // 01001, 'No project configuration file found - currently using default EXAMPLE identifiers. Auto-generating a proper config.json in your specifications folder', 'Open the config.json file and customize it for your project.', 'errorNumber'
       logger.warn('01001');
       return defaults;
     }
@@ -46,7 +47,7 @@ class Preprocessor extends SHRDataElementParserVisitor {
     // [1] Translate old IG fields to new IG fields
     const checkIgProperty = (oldPropertyName, igPropertyName) => {
       if (configFile[oldPropertyName] != null) {
-        // 01020, 'Configuration file '${oldPropertyName}' field will be deprecated. Use 'implementationGuide.${igPropertyName}' instead.', 'Replace old propery path with new property path',
+        // 01019, 'Configuration file '${oldPropertyName}' field will be deprecated. Use 'implementationGuide.${igPropertyName}' instead.', 'Replace old propery path with new property path',
         logger.warn({ oldPropertyName, igPropertyName }, '01019');
         configFile.implementationGuide = configFile.implementationGuide || {};
         configFile.implementationGuide[igPropertyName] = configFile[oldPropertyName];
@@ -107,7 +108,8 @@ class Preprocessor extends SHRDataElementParserVisitor {
     let ns = '';
     if(ctx.docHeader().namespace()) {
       ns = ctx.docHeader().namespace().getText();
-      logger.debug({shrId: ns}, 'Start preprocessing namespace');
+      // 01026, 'Start preprocessing namespace',,
+      logger.debug({shrId: ns}, '01026');
     }
     try {
       if (ctx.pathDefs()) {
@@ -154,7 +156,8 @@ class Preprocessor extends SHRDataElementParserVisitor {
         }
       }
     } finally {
-      logger.debug({shrId: ns}, 'Done preprocessing namespace');
+      // 01027, 'Done preprocessing namespace',,
+      logger.debug({shrId: ns}, '01027');
     }
   }
 
@@ -207,7 +210,7 @@ class PreprocessedData {
   resolvePath(name, ...namespace) {
     // First ensure namespaces were passed in
     if (namespace.length == 0) {
-      return { error: `Cannot resolve path without namespaces. ERROR_CODE:11017` };
+      return { error: `Cannot resolve path without namespaces` };
     }
 
     // Special handling for default paths
@@ -236,9 +239,9 @@ class PreprocessedData {
       }
     }
     if (!result.hasOwnProperty('url')) {
-      result['error'] = `Failed to resolve path for ${name}. ERROR_CODE:11018`;
+      result['error'] = `Failed to resolve path for ${name}`;
     } else if (conflict) {
-      result['error'] = `Found conflicting path for ${name} in multiple namespaces: ${foundNamespaces}. ERROR_CODE:11019`;
+      result['error'] = `Found conflicting path for ${name} in multiple namespaces: ${foundNamespaces}`;
     }
     return result;
   }
@@ -258,9 +261,9 @@ class PreprocessedData {
       }
     }
     if (!result.hasOwnProperty('url')) {
-      result['error'] = `Failed to resolve vocabulary for ${name}. ERROR_CODE:11020`;
+      result['error'] = `Failed to resolve vocabulary for ${name}`;
     } else if (conflict) {
-      result['error'] = `Found conflicting vocabularies for ${name} in multiple namespaces: ${foundNamespaces}. ERROR_CODE:11021`;
+      result['error'] = `Found conflicting vocabularies for ${name} in multiple namespaces: ${foundNamespaces}`;
     }
     return result;
   }
@@ -278,9 +281,9 @@ class PreprocessedData {
       }
     }
     if (!result.hasOwnProperty('namespace')) {
-      result['error'] = `Failed to resolve definition for ${name}. ERROR_CODE:11013`;
+      result['error'] = `Failed to resolve definition for ${name}`;
     } else if (foundNamespaces.length > 1) {
-      result['error'] = `Found conflicting definitions for ${name} in multiple namespaces: ${foundNamespaces}. ERROR_CODE:11022`;
+      result['error'] = `Found conflicting definitions for ${name} in multiple namespaces: ${foundNamespaces}`;
     }
     return result;
   }

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -33,11 +33,12 @@ class Preprocessor extends SHRDataElementParserVisitor {
     if (file != null) {
       try { configFile = JSON.parse(new FileStream(file)); }
       catch (e) {
-        logger.error('Invalid config file. Should be valid JSON dictionary. ERROR_CODE:11006');
+        //11006 , 'Invalid config file. Should be valid JSON dictionary' , 'Make sure your 'config.json' file is using a valid format for JSON.', 'errorNumber'
+        logger.error('11006');
         return defaults;
       }
     } else {
-      logger.warn(`No project configuration file found, currently using default EXAMPLE identifiers. Auto-generating a proper 'config.json' in your specifications folder. ERROR_CODE:01001`);
+      logger.warn('01001');
       return defaults;
     }
 
@@ -45,7 +46,8 @@ class Preprocessor extends SHRDataElementParserVisitor {
     // [1] Translate old IG fields to new IG fields
     const checkIgProperty = (oldPropertyName, igPropertyName) => {
       if (configFile[oldPropertyName] != null) {
-        logger.warn(`Configuration file '${oldPropertyName}' field will be deprecated. Use 'implementationGuide.${igPropertyName}' instead.`);
+        // 01020, 'Configuration file '${oldPropertyName}' field will be deprecated. Use 'implementationGuide.${igPropertyName}' instead.', 'Replace old propery path with new property path',
+        logger.warn({ oldPropertyName, igPropertyName }, '01019');
         configFile.implementationGuide = configFile.implementationGuide || {};
         configFile.implementationGuide[igPropertyName] = configFile[oldPropertyName];
         delete configFile[oldPropertyName];
@@ -77,7 +79,8 @@ class Preprocessor extends SHRDataElementParserVisitor {
     // Setup a child logger to associate logs with the current file
     const lastLogger = logger;
     logger = rootLogger.child({ file: file });
-    logger.debug('Start preprocessing data elements file');
+    // 01020, 'Start preprocessing data elements file',,
+    logger.debug('01020');
     try {
       const chars = new FileStream(file);
       const lexer = new SHRDataElementLexer(chars);
@@ -89,7 +92,8 @@ class Preprocessor extends SHRDataElementParserVisitor {
       const tree = parser.doc();
       this.visitDoc(tree);
     } finally {
-      logger.debug('Done preprocessing data elements file');
+      // 01021, 'Done preprocessing data elements file',,
+      logger.debug('01021');
       this.logger = lastLogger;
     }
   }
@@ -158,7 +162,8 @@ class Preprocessor extends SHRDataElementParserVisitor {
     const major = parseInt(version.WHOLE_NUMBER()[0], 10);
     const minor = parseInt(version.WHOLE_NUMBER()[2], 10);
     if (GRAMMAR_VERSION.major != major || GRAMMAR_VERSION.minor < minor) {
-      logger.error('Unsupported grammar version: %s.%s. ERROR_CODE:11007', major, minor);
+      //11007 , 'Unsupported grammar version: ${versionMajor}.${versionMinor} ' , 'Grammar Version for file must be 5.0 (or above)', 'errorNumber'
+      logger.error({versionMajor : major, versionMinor: minor}, '11007' );
       return false;
     }
     return true;
@@ -289,7 +294,8 @@ function fillInDefaultData(defaultData, configData, parentKeys = []) {
       fillInDefaultData(defaultData[key], configData[key], [...parentKeys, key]);
     } else if (configData[key] == null) {
       configData[key] = defaultData[key];
-      logger.warn('Configuration file missing key: %s, using default value: %s. ERROR_CODE:01002', [...parentKeys, key].join('.'), JSON.stringify(configData[key]));
+      // 01002, 'Config file missing key: ${key}  using default value: ${defaultValue} instead.', ' Open the config.json file and add your project specific details for that key.', 'errorNumber'
+      logger.warn({ key: [...parentKeys, key].join('.'), defaultValue: JSON.stringify(configData[key]) }, '01002');
     }
   }
 }

--- a/lib/valueSetListener.js
+++ b/lib/valueSetListener.js
@@ -78,14 +78,16 @@ class ValueSetImporter extends SHRValueSetParserListener {
     const minor = parseInt(version.WHOLE_NUMBER()[1], 10);
     this._currentGrammarVersion = new Version(major, minor);
 
-    logger.debug({shrId: this._currentNs, version: this._currentGrammarVersion.toString()}, 'Start importing value set namespace');
+    // 01028, 'Start importing value set namespace',,
+    logger.debug({shrId: this._currentNs, version: this._currentGrammarVersion.toString()}, '01028');
   }
 
   exitDoc(ctx) {
+    // 01029, 'Done importing value set namespace',,
+    logger.debug({shrId: this._currentNs}, '01029');
     // clear current namespace, target spec, and grammar version
     this._currentNs = '';
     this._currentGrammarVersion = null;
-    logger.debug({shrId: this._currentNs}, 'Done importing value set namespace');
   }
 
   enterVocabularyDef(ctx) {

--- a/lib/valueSetListener.js
+++ b/lib/valueSetListener.js
@@ -38,7 +38,8 @@ class ValueSetImporter extends SHRValueSetParserListener {
     // Setup a child logger to associate logs with the current file
     const lastLogger = logger;
     logger = rootLogger.child({ file: file });
-    logger.debug('Start importing value set file');
+    // 01022, 'Start importing value set file',,
+    logger.debug('01022');
     try {
       const errListener = new SHRErrorListener(logger);
       const chars = new FileStream(file);
@@ -54,7 +55,8 @@ class ValueSetImporter extends SHRValueSetParserListener {
       const walker = new ParseTreeWalker();
       walker.walk(this, tree);
     } finally {
-      logger.debug('Done importing value set file');
+      // 01023, 'Done importing value set file',,
+      logger.debug('01023');
       this.logger = lastLogger;
     }
   }
@@ -102,12 +104,14 @@ class ValueSetImporter extends SHRValueSetParserListener {
   enterValuesetDef(ctx) {
     const h = ctx.valuesetHeader();
     if (h.URL()) {
-      logger.error('Defining value sets by URL has been deprecated in ValueSet files.  ValueSet %s ignored. ERROR_CODE:11008', h.URL().getText());
+      //11008 , 'Defining value sets by URL has been deprecated in ValueSet files. ValueSet ${valueSet1} ignored.' , 'Define the value set with a name using proper syntax.', 'errorNumber'
+      logger.error( {valueSet1 : h.URL().getText() }, '11008');
       // Set a dummy unsupported def so the rest of the parsing can occur -- but it won't be added to the definitions
       this._currentDef = new ValueSet(new Identifier('unsupported', 'Unsupported'), 'urn:unsupported');
       return;
     } else if (h.URN_OID()) {
-      logger.error('Defining value sets by URN has been deprecated in ValueSet files.  ValueSet %s ignored. ERROR_CODE:11009', h.URN_OID().getText());
+      //11009 , 'Defining value sets by URN has been deprecated in ValueSet files. ValueSet ${valueSet1} ignored.' , 'Define the value set with a name using proper syntax.', 'errorNumber'
+      logger.error({valueSet1 : h.URN_OID().getText() }, '11009' );
       // Set a dummy unsupported def so the rest of the parsing can occur -- but it won't be added to the definitions
       this._currentDef = new ValueSet(new Identifier('unsupported', 'Unsupported'), 'urn:unsupported');
       return;
@@ -179,7 +183,8 @@ class ValueSetImporter extends SHRValueSetParserListener {
     const alias = ctx.ALL_CAPS().getText();
     const system = this._csMap.get(alias);
     if (typeof system === 'undefined') {
-      logger.error('Couldn\'t resolve code system for alias: %s. ERROR_CODE:11010', alias);
+      //11010 , 'Could not resolve code system for alias: ${alias1}', 'Invalid Codesystem  double check spelling' , 'errorNumber'
+      logger.error({alias1 : alias}, '11010');
       return;
     }
     this._currentDef.addValueSetIncludesFromCodeSystemRule(system);
@@ -197,11 +202,13 @@ class ValueSetImporter extends SHRValueSetParserListener {
   }
 
   enterUsesStatement(ctx) {
-    logger.error('Uses statements have been deprecated in ValueSet files.  Uses statement ignored. ERROR_CODE:11011');
+    //11011 , 'Uses statements have been deprecated in ValueSet files. Uses statement ignored.' , 'Uses statement is unnecessary. Refer to documentation for proper syntax', 'errorNumber'
+    logger.error('11011');
   }
 
   enterPathDef(ctx) {
-    logger.error('Only default path definitions are allowed in ValueSet files.  Path definition ignored. ERROR_CODE:11012');
+    //11012 , 'Only default path definitions are allowed in ValueSet files. Path definition ignored.' , 'Use one of the preset path definitions defined in the documentation.', 'errorNumber'
+    logger.error('11012');
   }
 
   processFullyQualifiedCode(ctx) {
@@ -209,7 +216,8 @@ class ValueSetImporter extends SHRValueSetParserListener {
       const alias = ctx.ALL_CAPS().getText();
       const system = this._csMap.get(alias);
       if (typeof system === 'undefined') {
-        logger.error('Couldn\'t resolve code system for alias: %s. ERROR_CODE:11010', alias);
+        //11010 , 'Could not resolve code system for alias: ${alias1}', 'Invalid Codesystem  double check spelling' , 'errorNumber'
+        logger.error({alias1 : alias}, '11010');
         return;
       }
       const code = ctx.code().CODE().getText().substr(1); // substr to skip the '#'
@@ -258,7 +266,8 @@ class ValueSetImporter extends SHRValueSetParserListener {
     }
 
     if (this._specs.valueSets.findByIdentifier(this._currentDef.identifier) != null) {
-      logger.error('Name "%s" already exists. ERROR_CODE:11034', this._currentDef.identifier.name);
+      //11034 , 'ValueSet name ${vsName} already exists.' , 'The value set name already exists within the namespace.', 'errorNumber'
+      logger.error({vsName : this._currentDef.identifier.name }, '11034' );
     }
 
     this._specs.valueSets.add(this._currentDef);

--- a/test/config-import-test.js
+++ b/test/config-import-test.js
@@ -127,7 +127,7 @@ describe('#importConfig', () => {
 
   it('Config6: should correctly throw error when file is not valid JSON', () => {
     const configuration = importConfiguration('invalidblankconfig', 1);
-    expect(err.errors()[0].msg).to.contain('Invalid config file');
+    expect(err.errors()[0].msg).to.contain('11046');
     expect(configuration).to.be.undefined;
   });
 


### PR DESCRIPTION
This takes the `errorMessages.txt` file which existed only in `shr-cli` and splits it into multiple files, so that each module has its own `errorMessages.txt` file. Also incorrectly numbered or otherwise broken errors were fixed. Tests that depended on the old error messages format were refactored.

PR 2/7
Affects:
- `shr-cli`
- `shr-text-import`
- `shr-expand`
- `shr-fhir-export`
- `shr-json-schema-export`
- `shr-json-javadoc`
- `shr-es6-export`