### PR TITLE
Remove support for Entry/_Entry keywords

### DIFF
--- a/errorMessages.txt
+++ b/errorMessages.txt
@@ -78,3 +78,4 @@ Number, Message, Solution, deduplicationKeys
 11056, 'Cannot declare properties on an Element since Elements do not have properties', 'Unknown', 'errorNumber'
 11057, 'Cannot constrain Value on a non-Element since non-Elements do not have Values', 'Unknown', 'errorNumber'
 11058, 'Cannot constrain properties on Elements since Elements only have Values', 'Unknown', 'errorNumber'
+11059, 'The Entry/_Entry keywords should no longer be used in field definitions or mappings', 'Remove Entry/_Entry from definitions and/or mappings and use appropriate elements from type hierarchy instead.', 'errorNumber'

--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -84,7 +84,7 @@ class DataElementImporter extends SHRDataElementParserListener {
     if (ctx.descriptionProp() && typeof nsDef.description === 'undefined') {
       nsDef.description = trimLines(stripDelimitersFromToken(ctx.descriptionProp().STRING()));
     }
-    
+
     // Process the version
     let docHeader = ctx.docHeader();
     if (docHeader.version()) {
@@ -521,7 +521,8 @@ class DataElementImporter extends SHRDataElementParserListener {
       }
       // If we got here, it might be the old Entry keyword, in which case we should log an error
       if (field.identifier.namespace === '' && (field.identifier.name === '_Entry' || field.identifier.name === 'Entry')) {
-        logger.error('The Entry/_Entry keywords should no longer be used in field definitions or mappings'); // Add error # in logging refactor branch
+        // 11059, 'The Entry/_Entry keywords should no longer be used in field definitions or mappings', 'Remove Entry/_Entry from definitions and/or mappings and use appropriate elements from type hierarchy instead.', 'errorNumber'
+        logger.error('11059');
         return;
       }
     }

--- a/lib/dataElementListener.js
+++ b/lib/dataElementListener.js
@@ -519,13 +519,9 @@ class DataElementImporter extends SHRDataElementParserListener {
           return;
         }
       }
-      // If we got here, we didn't find anything -- but if it's an Entry field, resolve it to a 1..1 IdentifiableValue
-      if (field.identifier.isEntryKeyWord) {
-        const entryField = new IdentifiableValue(field.identifier).withMinMax(1, 1);
-        for (const cst of field.constraints) {
-          entryField.addConstraint(cst);
-        }
-        this._currentDef.addField(entryField);
+      // If we got here, it might be the old Entry keyword, in which case we should log an error
+      if (field.identifier.namespace === '' && (field.identifier.name === '_Entry' || field.identifier.name === 'Entry')) {
+        logger.error('The Entry/_Entry keywords should no longer be used in field definitions or mappings'); // Add error # in logging refactor branch
         return;
       }
     }
@@ -755,7 +751,7 @@ class DataElementImporter extends SHRDataElementParserListener {
     // No specified namespace -- is either special word (e.g. _Value), primitive, or something we need to resolve
     if (ref.startsWith('_')) {
       return new Identifier('', ref);
-    } else if (ref === 'Entry' || ref === 'Value') {
+    } else if (ref === 'Value') {
       // "Fix" the legacy keyword to the new _-based keyword
       return new Identifier('', `_${ref}`);
     } else if (PRIMITIVES.includes(ref)) {

--- a/lib/mappingListener.js
+++ b/lib/mappingListener.js
@@ -181,9 +181,12 @@ class MappingImporter extends SHRMapParserListener {
     }
 
     // No specified namespace -- if it's a special word (e.g. _Value), or primitive, make it so.
-    if (ref.startsWith('_')) {
+    if (ref === 'Entry' || ref === '_Entry' ) {
+      logger.error('The Entry/_Entry keywords should no longer be used in field definitions or mappings'); // Add error # in logging refactor branch
+      // Don't return; allow an identifier to be made anyway -- as invokers don't expect to get null back
+    } else if (ref.startsWith('_')) {
       return new Identifier('', ref);
-    } else if (ref === 'Entry' || ref === 'Value') {
+    }  else if (ref === 'Value') {
       // "Fix" the legacy keyword to the new _-based keyword
       return new Identifier('', `_${ref}`);
     } else if (PRIMITIVES.includes(ref)) {

--- a/lib/mappingListener.js
+++ b/lib/mappingListener.js
@@ -182,7 +182,8 @@ class MappingImporter extends SHRMapParserListener {
 
     // No specified namespace -- if it's a special word (e.g. _Value), or primitive, make it so.
     if (ref === 'Entry' || ref === '_Entry' ) {
-      logger.error('The Entry/_Entry keywords should no longer be used in field definitions or mappings'); // Add error # in logging refactor branch
+      // 11059, 'The Entry/_Entry keywords should no longer be used in field definitions or mappings', 'Remove Entry/_Entry from definitions and/or mappings and use appropriate elements from type hierarchy instead.', 'errorNumber'
+      logger.error('11059');
       // Don't return; allow an identifier to be made anyway -- as invokers don't expect to get null back
     } else if (ref.startsWith('_')) {
       return new Identifier('', ref);

--- a/test/fixtures/map/SpecialWordMapping_map.txt
+++ b/test/fixtures/map/SpecialWordMapping_map.txt
@@ -4,13 +4,11 @@ Target:		TEST
 
 A maps to B:
 	_Concept maps to testW
-	_Entry maps to testX
 	_Value maps to testY
 	C._Value maps to testZ
 
-// Test backwards compatibility, Entry/Value should get converted to _Entry/_Value
+// Test backwards compatibility, Value should get converted to _Value
 A2 maps to B2:
 	_Concept maps to testW
-	Entry maps to testX
 	Value maps to testY
 	C.Value maps to testZ

--- a/test/map-import-test.js
+++ b/test/map-import-test.js
@@ -42,14 +42,12 @@ describe('#importMapping', () => {
     let s = getAndExpect(specifications, 'shr.test', 'A', 'TEST', 'B');
     expect(s.rules).to.eql([
       new mdls.FieldMappingRule([id('', '_Concept')], 'testW'),
-      new mdls.FieldMappingRule([id('', '_Entry')], 'testX'),
       new mdls.FieldMappingRule([id('', '_Value')], 'testY'),
       new mdls.FieldMappingRule([sid('C'), id('', '_Value')], 'testZ')
     ]);
     s = getAndExpect(specifications, 'shr.test', 'A2', 'TEST', 'B2');
     expect(s.rules).to.eql([
       new mdls.FieldMappingRule([id('', '_Concept')], 'testW'),
-      new mdls.FieldMappingRule([id('', '_Entry')], 'testX'),
       new mdls.FieldMappingRule([id('', '_Value')], 'testY'),
       new mdls.FieldMappingRule([sid('C'), id('', '_Value')], 'testZ')
     ]);


### PR DESCRIPTION
"Entryness" affects implementations of data elements, but should not automatically add special fields to the model itself.  As such, there is no longer any valid need for Entry/_Entry keywords.

In case someone is still using these keywords, we log an error letting them know it isn't supported anymore.

This is PR 2 of 7 in the overall effort to remove the need for the shr.base.Entry element.

1. shr-models (standardhealth/shr-models#49)
2. shr-text-import
3. shr-expand (standardhealth/shr-expand#49)
4. shr-json-javadoc (standardhealth/shr-json-javadoc#28)
5. shr-json-schema-export (standardhealth/shr-json-schema-export#17)
6. shr-fhir-export (standardhealth/shr-fhir-export#165)
7. shr-es6-export (standardhealth/shr-es6-export#60)